### PR TITLE
Expand Frostpeak collection to 100 stories and add story files + index

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Prefer the branch's expanded story content when resolving merges.
+stories/story_*.md merge=ours

--- a/CHARACTER_AND_STORY_GUIDE.md
+++ b/CHARACTER_AND_STORY_GUIDE.md
@@ -162,3 +162,13 @@ After edits, verify:
 
 *"He gives sleep to His beloved." — Psalm 127:2*  
 *Now zip your sleeping bag, sip imaginary cocoa, and drift to dream-snow.*
+
+---
+
+## EXPANDED COLLECTION NOTE
+
+The project now includes an expanded **100-story** collection.
+- Core Story Guide table above highlights the foundational first 20 stories.
+- For the full linked list of stories 1–100, see [FROSTPEAK_100_BIBLE_BEDTIME_STORIES.md](FROSTPEAK_100_BIBLE_BEDTIME_STORIES.md).
+- Each story exists as an individual file in [`stories/`](stories) and includes a Goodnight Blessing plus image/video prompts.
+

--- a/FROSTPEAK_100_BIBLE_BEDTIME_STORIES.md
+++ b/FROSTPEAK_100_BIBLE_BEDTIME_STORIES.md
@@ -1,0 +1,106 @@
+# Frostpeak Valley: 100 Silly Winter Bible Bedtime Stories
+
+This catalog now links to **100 individual story files** in `stories/`, each with full story text plus Goodnight Blessing, Image Prompts, and Video Prompts.
+
+## Complete Linked Story List
+
+1. [The Great Slush Flood](stories/story_01_the_great_slush_flood.md) — *Inspired by Noah's Ark — Genesis 6–9*
+2. [Willa and the Giant Snowball](stories/story_02_willa_and_the_giant_snowball.md) — *Inspired by David and Goliath — 1 Samuel 17*
+3. [The Penguin Left on the Slope](stories/story_03_the_penguin_left_on_the_slope.md) — *Inspired by The Good Samaritan — Luke 10:25–37*
+4. [Finnegan Goes the Wrong Way](stories/story_04_finnegan_goes_the_wrong_way.md) — *Inspired by Jonah and the Whale — Jonah 1–3*
+5. [The First Morning on Frostpeak](stories/story_05_the_first_morning_on_frostpeak.md) — *Inspired by The Creation — Genesis 1–2*
+6. [Piper and the Parting Snow](stories/story_06_piper_and_the_parting_snow.md) — *Inspired by Moses and the Red Sea — Exodus 14*
+7. [Cleo and the Frozen Lions](stories/story_07_cleo_and_the_frozen_lions.md) — *Inspired by Daniel in the Lions' Den — Daniel 6*
+8. [One Fish, Five Thousand Mouths](stories/story_08_one_fish_five_thousand_mouths.md) — *Inspired by the Feeding of the Five Thousand — John 6:1–14*
+9. [The Little Lost Boarder](stories/story_09_the_little_lost_boarder.md) — *Inspired by The Parable of the Lost Sheep — Luke 15:1–7*
+10. [The Tower of Snow](stories/story_10_the_tower_of_snow.md) — *Inspired by The Tower of Babel — Genesis 11:1–9*
+11. [The Night the Wind Stopped](stories/story_11_the_night_the_wind_stopped.md) — *Inspired by Jesus Calms the Storm — Mark 4:35–41*
+12. [The Boarder Who Came Home](stories/story_12_the_boarder_who_came_home.md) — *Inspired by The Prodigal Son — Luke 15:11–32*
+13. [Barnaby and the Seventy-Times Sled](stories/story_13_barnaby_and_the_seventy_times_sled.md) — *Inspired by Forgive Seventy Times Seven — Matthew 18:21–22*
+14. [Piper on the Moonlit Ice](stories/story_14_piper_on_the_moonlit_ice.md) — *Inspired by Peter Walks on Water — Matthew 14:22–33*
+15. [Willa and the Midnight Lamps](stories/story_15_willa_and_the_midnight_lamps.md) — *Inspired by The Wise and Foolish Virgins — Matthew 25:1–13*
+16. [The Hidden Fish Treasure](stories/story_16_the_hidden_fish_treasure.md) — *Inspired by The Hidden Treasure — Matthew 13:44*
+17. [The Tiny Seed on Ice](stories/story_17_the_tiny_seed_on_ice.md) — *Inspired by The Mustard Seed — Matthew 13:31–32*
+18. [Magnus and the Second Mile](stories/story_18_magnus_and_the_second_mile.md) — *Inspired by Go the Second Mile — Matthew 5:41*
+19. [Cleo and the Lost Coin Bell](stories/story_19_cleo_and_the_lost_coin_bell.md) — *Inspired by The Lost Coin — Luke 15:8–10*
+20. [The House on the Ice Rock](stories/story_20_the_house_on_the_ice_rock.md) — *Inspired by The Wise and Foolish Builders — Matthew 7:24–27*
+21. [The Rainbow Over Rink Ridge](stories/story_21_the_rainbow_over_rink_ridge.md) — *Inspired by God's Promise After the Flood — Genesis 9:8–17*
+22. [Abby and the Star-Count Camp](stories/story_22_abby_and_the_star_count_camp.md) — *Inspired by God's Promise to Abraham — Genesis 15:1–6*
+23. [The Laughing Tent in Snowfield](stories/story_23_the_laughing_tent_in_snowfield.md) — *Inspired by Sarah Laughs — Genesis 18:1–15*
+24. [Jacob's Icy Ladder Dream](stories/story_24_jacobs_icy_ladder_dream.md) — *Inspired by Jacob's Ladder — Genesis 28:10–22*
+25. [The Scarf Trade on Twin Run](stories/story_25_the_scarf_trade_on_twin_run.md) — *Inspired by Jacob and Esau Reconcile — Genesis 33*
+26. [Joey's Many-Colored Mittens](stories/story_26_joeys_many_colored_mittens.md) — *Inspired by Joseph's Dreams — Genesis 37*
+27. [The Grain-Barn Blizzard Plan](stories/story_27_the_grain_barn_blizzard_plan.md) — *Inspired by Joseph Saves for Famine — Genesis 41*
+28. [The Basket on the River Ice](stories/story_28_the_basket_on_the_river_ice.md) — *Inspired by Baby Moses — Exodus 2*
+29. [The Burning Berry Bush](stories/story_29_the_burning_berry_bush.md) — *Inspired by The Burning Bush — Exodus 3*
+30. [Frogs on the Halfpipe](stories/story_30_frogs_on_the_halfpipe.md) — *Inspired by The Plagues (soft retelling) — Exodus 7–12*
+31. [Manna Flakes at Dawn](stories/story_31_manna_flakes_at_dawn.md) — *Inspired by Manna in the Wilderness — Exodus 16*
+32. [Ten Snowy Signposts](stories/story_32_ten_snowy_signposts.md) — *Inspired by The Ten Commandments — Exodus 20*
+33. [The Golden Snow-Calf Oops](stories/story_33_the_golden_snow_calf_oops.md) — *Inspired by The Golden Calf — Exodus 32*
+34. [Rahab's Scarlet Ski Rope](stories/story_34_rahabs_scarlet_ski_rope.md) — *Inspired by Rahab and the Scarlet Cord — Joshua 2*
+35. [The Trumpets of Jericho Jump](stories/story_35_the_trumpets_of_jericho_jump.md) — *Inspired by Jericho — Joshua 6*
+36. [Gideon's Tiny Team Tumble](stories/story_36_gideons_tiny_team_tumble.md) — *Inspired by Gideon's Small Army — Judges 7*
+37. [Deborah's Drumline Downhill](stories/story_37_deborahs_drumline_downhill.md) — *Inspired by Deborah Leads Israel — Judges 4*
+38. [Ruth and the Barley Blizzard](stories/story_38_ruth_and_the_barley_blizzard.md) — *Inspired by Ruth — Ruth 1–4*
+39. [Hannah's Quiet Rink Prayer](stories/story_39_hannahs_quiet_rink_prayer.md) — *Inspired by Hannah's Prayer — 1 Samuel 1*
+40. [The Little Lantern King](stories/story_40_the_little_lantern_king.md) — *Inspired by Samuel Anoints David — 1 Samuel 16*
+41. [The Harp on Ice](stories/story_41_the_harp_on_ice.md) — *Inspired by David Soothes Saul — 1 Samuel 16:23*
+42. [Ravens and the Snack Drop](stories/story_42_ravens_and_snack_drop.md) — *Inspired by Elijah Fed by Ravens — 1 Kings 17*
+43. [The Fire on Frost Mountain](stories/story_43_the_fire_on_frost_mountain.md) — *Inspired by Elijah on Mount Carmel — 1 Kings 18*
+44. [The Whisper in the Snow Cave](stories/story_44_the_whisper_in_the_snow_cave.md) — *Inspired by Still Small Voice — 1 Kings 19*
+45. [Naaman's Seven Splashes](stories/story_45_naamans_seven_splashes.md) — *Inspired by Naaman Healed — 2 Kings 5*
+46. [The Axe That Floated](stories/story_46_the_ax_that_floated.md) — *Inspired by Floating Axe Head — 2 Kings 6*
+47. [Esther's Brave Banquet](stories/story_47_esthers_brave_banquet.md) — *Inspired by Esther's Courage — Esther 4–7*
+48. [Job and the Long Snow Night](stories/story_48_job_and_the_long_snow_night.md) — *Inspired by Job — Job 1–42*
+49. [The Psalm-Song Lift](stories/story_49_the_psalm_song_lift.md) — *Inspired by Psalms*
+50. [King Sol's Wisdom Race](stories/story_50_king_sols_wisdom_race.md) — *Inspired by Solomon's Wisdom — 1 Kings 3*
+51. [The Snow Queen of Sheba](stories/story_51_the_snow_queen_of_sheba.md) — *Inspired by Queen of Sheba Visits Solomon — 1 Kings 10*
+52. [The Writing on the Ice Wall](stories/story_52_the_writing_on_the_ice_wall.md) — *Inspired by Writing on the Wall — Daniel 5*
+53. [Shadrach's Snowproof Suits](stories/story_53_shadrachs_snowproof_suits.md) — *Inspired by Fiery Furnace — Daniel 3*
+54. [The Valley of Dancing Bones](stories/story_54_the_valley_of_dancing_bones.md) — *Inspired by Valley of Dry Bones — Ezekiel 37*
+55. [The Census Sled Journey](stories/story_55_the_census_sled_journey.md) — *Inspired by Journey to Bethlehem — Luke 2:1–5*
+56. [The Stable by the Ski Lodge](stories/story_56_the_stable_by_the_ski_lodge.md) — *Inspired by Birth of Jesus — Luke 2:6–20*
+57. [Shepherds on the Night Shift](stories/story_57_shepherds_on_the_night_shift.md) — *Inspired by Shepherds and Angels — Luke 2*
+58. [The Stargazer Snow Kings](stories/story_58_the_stargazer_snow_kings.md) — *Inspired by Wise Men Follow the Star — Matthew 2*
+59. [The Voice by Frozen River](stories/story_59_the_voice_by_frozen_river.md) — *Inspired by John the Baptist — Matthew 3*
+60. [Forty Days on Windy Peak](stories/story_60_forty_days_on_windy_peak.md) — *Inspired by Temptation in the Wilderness — Matthew 4*
+61. [The Net Full of Silverfish](stories/story_61_the_net_full_of_silverfish.md) — *Inspired by Calling the First Disciples — Luke 5*
+62. [The Picnic on Powder Hill](stories/story_62_the_picnic_on_powder_hill.md) — *Inspired by Sermon on the Mount — Matthew 5–7*
+63. [The Rooftop Sled Rescue](stories/story_63_the_rooftop_sled_rescue.md) — *Inspired by Friends Lower a Man Through Roof — Mark 2*
+64. [Matty's Tax-Booth Turnaround](stories/story_64_mattys_tax_booth_turnaround.md) — *Inspired by Calling Matthew — Matthew 9*
+65. [Martha, Mia, and the Cocoa Kettle](stories/story_65_martha_mia_and_cocoa_kettle.md) — *Inspired by Mary and Martha — Luke 10*
+66. [Treasure Under the Halfpipe](stories/story_66_treasure_under_the_halfpipe.md) — *Inspired by Treasure in the Field — Matthew 13:44*
+67. [The Pearl of Great Powder](stories/story_67_the_pearl_of_great_powder.md) — *Inspired by Pearl of Great Price — Matthew 13:45–46*
+68. [The Unforgiving Skate Captain](stories/story_68_the_unforgiving_skate_captain.md) — *Inspired by Unforgiving Servant — Matthew 18*
+69. [Workers at Sunset Slope](stories/story_69_workers_at_sunset_slope.md) — *Inspired by Workers in the Vineyard — Matthew 20*
+70. [The Little Donkey Snow Parade](stories/story_70_the_little_donkey_snow_parade.md) — *Inspired by Triumphal Entry — Matthew 21*
+71. [The Widow's Two Snowflakes](stories/story_71_the_widows_two_snowflakes.md) — *Inspired by Widow's Offering — Mark 12*
+72. [Last Supper Soup Night](stories/story_72_last_supper_soup_night.md) — *Inspired by The Last Supper — Luke 22*
+73. [The Towel and Skate Boots](stories/story_73_the_towel_and_skate_boots.md) — *Inspired by Jesus Washes Feet — John 13*
+74. [Garden of Snowflakes](stories/story_74_garden_of_snowflakes.md) — *Inspired by Prayer in Gethsemane — Matthew 26*
+75. [Rooster at the Rink Gate](stories/story_75_rooster_at_the_rink_gate.md) — *Inspired by Peter Denies Jesus — Luke 22*
+76. [The Cross on Calvary Hill](stories/story_76_the_cross_on_calvary_hill.md) — *Inspired by Crucifixion — Luke 23*
+77. [Sunrise at the Empty Igloo](stories/story_77_sunrise_empty_igloo.md) — *Inspired by Resurrection — John 20*
+78. [Breakfast by Frozen Shore](stories/story_78_breakfast_by_frozen_shore.md) — *Inspired by Breakfast by the Shore — John 21*
+79. [The Great Snowy Send-Off](stories/story_79_the_great_snowy_sendoff.md) — *Inspired by Great Commission — Matthew 28:18–20*
+80. [Wind at the Winter Festival](stories/story_80_wind_at_winter_festival.md) — *Inspired by Pentecost — Acts 2*
+81. [Peter's Picnic Blanket Surprise](stories/story_81_peters_picnic_blanket.md) — *Inspired by Peter and Cornelius — Acts 10*
+82. [Jailhouse Jingle on Ice](stories/story_82_jailhouse_jingle_on_ice.md) — *Inspired by Paul and Silas in Prison — Acts 16*
+83. [Shipwreck Snowdrift Rescue](stories/story_83_shipwreck_snowdrift_rescue.md) — *Inspired by Paul's Shipwreck — Acts 27*
+84. [Armor on Ice](stories/story_84_armor_on_ice.md) — *Inspired by Armor of God — Ephesians 6*
+85. [Fruit of the Snow Spirit](stories/story_85_fruit_of_the_snow_spirit.md) — *Inspired by Fruit of the Spirit — Galatians 5*
+86. [Love on the Chairlift](stories/story_86_love_on_the_chairlift.md) — *Inspired by Love Is Patient — 1 Corinthians 13*
+87. [Run to Win the Wreath](stories/story_87_run_to_win_the_wreath.md) — *Inspired by Run the Race — 1 Corinthians 9*
+88. [Joy Letter from the Snow Cell](stories/story_88_joy_letter_from_snow_cell.md) — *Inspired by Philippians*
+89. [The New Coat Self](stories/story_89_the_new_coat_self.md) — *Inspired by Colossians 3*
+90. [Cloud of Snowy Witnesses](stories/story_90_cloud_of_snowy_witnesses.md) — *Inspired by Hebrews 12*
+91. [Taming the Tiny Tongue](stories/story_91_taming_the_tiny_tongue.md) — *Inspired by James 3*
+92. [Faith and the Ice Bridge](stories/story_92_faith_and_ice_bridge.md) — *Inspired by James 2*
+93. [Fiery Dart Snowballs](stories/story_93_fiery_dart_snowballs.md) — *Inspired by 1 Peter 5*
+94. [The Good Shepherd Ski Whistle](stories/story_94_good_shepherd_ski_whistle.md) — *Inspired by The Good Shepherd — John 10*
+95. [Wedding Feast on White Mountain](stories/story_95_wedding_feast_white_mountain.md) — *Inspired by Wedding Banquet — Matthew 22*
+96. [Oil for the Snow Lamps](stories/story_96_oil_for_snow_lamps.md) — *Inspired by Ten Virgins — Matthew 25*
+97. [Zacchaeus and the Tree Lift](stories/story_97_zacchaeus_tree_lift.md) — *Inspired by Zacchaeus — Luke 19*
+98. [Friend at Midnight Cocoa](stories/story_98_friend_at_midnight_cocoa.md) — *Inspired by Friend at Midnight — Luke 11*
+99. [The New Sky Snow Carnival](stories/story_99_new_sky_snow_carnival.md) — *Inspired by A New Heaven and New Earth — Revelation 21*
+100. [River of Life Ice Rink](stories/story_100_river_of_life_ice_rink.md) — *Inspired by River of Life — Revelation 22*

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Penguins on Snowboards & Polar Bears on Skis
-## 20 Bedtime Stories from Frostpeak Valley
+## 100 Bedtime Stories from Frostpeak Valley
 
 ---
 
-A collection of 20 original bedtime stories set in the snowy, magical world of **Frostpeak Valley** — where penguins ride snowboards, polar bears carve the slopes on skis, and winter creatures bring giggles to every trail. Each story is a playful winter allegory inspired by a beloved Bible story, reimagined with wonder, warmth, and just the right amount of silliness for little dreamers.
+A collection of 100 original bedtime stories set in the snowy, magical world of **Frostpeak Valley** — where penguins ride snowboards, polar bears carve the slopes on skis, and winter creatures bring giggles to every trail. Each story is a playful winter allegory inspired by a beloved Bible story, reimagined with wonder, warmth, and just the right amount of silliness for little dreamers.
 
 Each story includes **image prompts** and **video prompts** for bringing the tales to life visually, plus a soothing **Goodnight Blessing** to close each night.
 
@@ -11,7 +11,7 @@ Each story includes **image prompts** and **video prompts** for bringing the tal
 
 ---
 
-## The Stories
+## Core Stories (1–20)
 
 | # | Title | Bible Inspiration | Theme |
 |---|---|---|---|
@@ -61,3 +61,13 @@ See the full [Character & Story Guide](CHARACTER_AND_STORY_GUIDE.md) for:
 *"He gives sleep to his beloved." — Psalm 127:2*
 
 *Sweet dreams from Frostpeak Valley.*
+
+---
+
+## Full 100-Story Collection
+
+Explore the complete linked catalog (stories 1–100):
+
+- [Frostpeak Valley: 100 Silly Winter Bible Bedtime Stories](FROSTPEAK_100_BIBLE_BEDTIME_STORIES.md)
+
+All stories live in the [`stories/`](stories) folder as individual files and follow the same bedtime format (story, cozy landing, blessing, image prompts, and video prompts).

--- a/stories/story_100_river_of_life_ice_rink.md
+++ b/stories/story_100_river_of_life_ice_rink.md
@@ -1,0 +1,133 @@
+# Story 100: River of Life Ice Rink
+### *Inspired by River of Life — Revelation 22*
+**Characters:** Riv Robin, Cleo Coldwater  
+**Setting:** Frostpeak Valley, Crystal River Rink  
+**Theme:** Healing joy
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Crystal River Rink** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Riv Robin tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowboard relay**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Cleo Coldwater handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Riv Robin took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **River of Life — Revelation 22**.
+
+"Wait," Riv Robin said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Cleo Coldwater called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Healing joy**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Riv Robin looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Riv Robin slowed beside Cleo Coldwater and smiled. "The old stories are still alive," Riv Robin said. "They just wear snow boots now." Cleo Coldwater laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** River of Life — Revelation 22
+- **Theme Check:** Healing joy
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 100: River of Life Ice Rink**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> River of Life Ice Rink in Frostpeak Valley, Crystal River Rink, with Riv Robin and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowboard relay; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by River of Life — Revelation 22; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Crystal River Rink as friends gather for a snowboard relay; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from River of Life — Revelation 22, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_21_the_rainbow_over_rink_ridge.md
+++ b/stories/story_21_the_rainbow_over_rink_ridge.md
@@ -1,0 +1,133 @@
+# Story 21: The Rainbow Over Rink Ridge
+### *Inspired by God's Promise After the Flood — Genesis 9:8–17*
+**Characters:** Piper Paddlefoot, Cleo Coldwater, Captain Prism  
+**Setting:** Frostpeak Valley, Frozen Mirror Lake Rim  
+**Theme:** Promise-keeping and hope after storms
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Frozen Mirror Lake Rim** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Piper Paddlefoot tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **cross-country challenge**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Cleo Coldwater handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Piper Paddlefoot took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **God's Promise After the Flood — Genesis 9:8–17**.
+
+"Wait," Piper Paddlefoot said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Cleo Coldwater called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Promise-keeping and hope after storms**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Piper Paddlefoot looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Piper Paddlefoot slowed beside Cleo Coldwater and smiled. "The old stories are still alive," Piper Paddlefoot said. "They just wear snow boots now." Cleo Coldwater laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** God's Promise After the Flood — Genesis 9:8–17
+- **Theme Check:** Promise-keeping and hope after storms
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 21: The Rainbow Over Rink Ridge**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Rainbow Over Rink Ridge in Frostpeak Valley, Frozen Mirror Lake Rim, with Piper Paddlefoot and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a cross-country challenge; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by God's Promise After the Flood — Genesis 9:8–17; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Frozen Mirror Lake Rim as friends gather for a cross-country challenge; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from God's Promise After the Flood — Genesis 9:8–17, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_22_abby_and_the_star_count_camp.md
+++ b/stories/story_22_abby_and_the_star_count_camp.md
@@ -1,0 +1,133 @@
+# Story 22: Abby and the Star-Count Camp
+### *Inspired by God's Promise to Abraham — Genesis 15:1–6*
+**Characters:** Willa Wobble, Nora Snowmane, Abby Arctic-Hare  
+**Setting:** Frostpeak Valley, Stargazer Ridge  
+**Theme:** Hope while waiting
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Stargazer Ridge** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Willa Wobble tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **curling scramble**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Nora Snowmane handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Willa Wobble took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **God's Promise to Abraham — Genesis 15:1–6**.
+
+"Wait," Willa Wobble said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Nora Snowmane called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Hope while waiting**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Willa Wobble looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Willa Wobble slowed beside Nora Snowmane and smiled. "The old stories are still alive," Willa Wobble said. "They just wear snow boots now." Nora Snowmane laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** God's Promise to Abraham — Genesis 15:1–6
+- **Theme Check:** Hope while waiting
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 22: Abby and the Star-Count Camp**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Abby and the Star-Count Camp in Frostpeak Valley, Stargazer Ridge, with Willa Wobble and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a curling scramble; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by God's Promise to Abraham — Genesis 15:1–6; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Stargazer Ridge as friends gather for a curling scramble; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from God's Promise to Abraham — Genesis 15:1–6, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_23_the_laughing_tent_in_snowfield.md
+++ b/stories/story_23_the_laughing_tent_in_snowfield.md
@@ -1,0 +1,133 @@
+# Story 23: The Laughing Tent in Snowfield
+### *Inspired by Sarah Laughs — Genesis 18:1–15*
+**Characters:** Barnaby Beaksworth, Teddy & Tilda Powderpuff  
+**Setting:** Frostpeak Valley, Snowfield Camp  
+**Theme:** Surprising joy
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Snowfield Camp** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Barnaby Beaksworth tightened a scarf, looked up at the gold-and-violet sunset haze, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **biathlon loop**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Teddy & Tilda Powderpuff handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Barnaby Beaksworth took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Sarah Laughs — Genesis 18:1–15**.
+
+"Wait," Barnaby Beaksworth said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Teddy & Tilda Powderpuff called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Surprising joy**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Barnaby Beaksworth looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Barnaby Beaksworth slowed beside Teddy & Tilda Powderpuff and smiled. "The old stories are still alive," Barnaby Beaksworth said. "They just wear snow boots now." Teddy & Tilda Powderpuff laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Sarah Laughs — Genesis 18:1–15
+- **Theme Check:** Surprising joy
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 23: The Laughing Tent in Snowfield**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Laughing Tent in Snowfield in Frostpeak Valley, Snowfield Camp, with Barnaby Beaksworth and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a biathlon loop; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Sarah Laughs — Genesis 18:1–15; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Snowfield Camp as friends gather for a biathlon loop; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Sarah Laughs — Genesis 18:1–15, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_24_jacobs_icy_ladder_dream.md
+++ b/stories/story_24_jacobs_icy_ladder_dream.md
@@ -1,0 +1,133 @@
+# Story 24: Jacob's Icy Ladder Dream
+### *Inspired by Jacob's Ladder — Genesis 28:10–22*
+**Characters:** Finnegan Flipsworth, Whistlewick  
+**Setting:** Frostpeak Valley, North Pass  
+**Theme:** God is near in lonely places
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **North Pass** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Finnegan Flipsworth tightened a scarf, looked up at the powder-soft snowfall, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ski slalom**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Whistlewick handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Finnegan Flipsworth took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Jacob's Ladder — Genesis 28:10–22**.
+
+"Wait," Finnegan Flipsworth said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Whistlewick called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **God is near in lonely places**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Finnegan Flipsworth looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Finnegan Flipsworth slowed beside Whistlewick and smiled. "The old stories are still alive," Finnegan Flipsworth said. "They just wear snow boots now." Whistlewick laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Jacob's Ladder — Genesis 28:10–22
+- **Theme Check:** God is near in lonely places
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 24: Jacob's Icy Ladder Dream**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Jacob's Icy Ladder Dream in Frostpeak Valley, North Pass, with Finnegan Flipsworth and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ski slalom; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Jacob's Ladder — Genesis 28:10–22; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, North Pass as friends gather for a ski slalom; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Jacob's Ladder — Genesis 28:10–22, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_25_the_scarf_trade_on_twin_run.md
+++ b/stories/story_25_the_scarf_trade_on_twin_run.md
@@ -1,0 +1,133 @@
+# Story 25: The Scarf Trade on Twin Run
+### *Inspired by Jacob and Esau Reconcile — Genesis 33*
+**Characters:** Bjorn Bigpaws, Aurora Frostholm, twin ermine racers  
+**Setting:** Frostpeak Valley, Twin Run  
+**Theme:** Making peace after hurt
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Twin Run** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Bjorn Bigpaws tightened a scarf, looked up at the sparkling moon frost, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ice-dance parade**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Aurora Frostholm handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Bjorn Bigpaws took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Jacob and Esau Reconcile — Genesis 33**.
+
+"Wait," Bjorn Bigpaws said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Aurora Frostholm called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Making peace after hurt**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Bjorn Bigpaws looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Bjorn Bigpaws slowed beside Aurora Frostholm and smiled. "The old stories are still alive," Bjorn Bigpaws said. "They just wear snow boots now." Aurora Frostholm laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Jacob and Esau Reconcile — Genesis 33
+- **Theme Check:** Making peace after hurt
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 25: The Scarf Trade on Twin Run**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Scarf Trade on Twin Run in Frostpeak Valley, Twin Run, with Bjorn Bigpaws and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ice-dance parade; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Jacob and Esau Reconcile — Genesis 33; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Twin Run as friends gather for a ice-dance parade; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Jacob and Esau Reconcile — Genesis 33, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_26_joeys_many_colored_mittens.md
+++ b/stories/story_26_joeys_many_colored_mittens.md
@@ -1,0 +1,133 @@
+# Story 26: Joey's Many-Colored Mittens
+### *Inspired by Joseph's Dreams — Genesis 37*
+**Characters:** Cleo Coldwater, Barnaby Beaksworth  
+**Setting:** Frostpeak Valley, Mittens Meadow  
+**Theme:** Jealousy and purpose
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Mittens Meadow** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Cleo Coldwater tightened a scarf, looked up at the gentle aurora glow, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **sled sprint**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Barnaby Beaksworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Cleo Coldwater took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Joseph's Dreams — Genesis 37**.
+
+"Wait," Cleo Coldwater said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Barnaby Beaksworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Jealousy and purpose**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Cleo Coldwater looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Cleo Coldwater slowed beside Barnaby Beaksworth and smiled. "The old stories are still alive," Cleo Coldwater said. "They just wear snow boots now." Barnaby Beaksworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Joseph's Dreams — Genesis 37
+- **Theme Check:** Jealousy and purpose
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 26: Joey's Many-Colored Mittens**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Joey's Many-Colored Mittens in Frostpeak Valley, Mittens Meadow, with Cleo Coldwater and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a sled sprint; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Joseph's Dreams — Genesis 37; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Mittens Meadow as friends gather for a sled sprint; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Joseph's Dreams — Genesis 37, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_27_the_grain_barn_blizzard_plan.md
+++ b/stories/story_27_the_grain_barn_blizzard_plan.md
@@ -1,0 +1,133 @@
+# Story 27: The Grain-Barn Blizzard Plan
+### *Inspired by Joseph Saves for Famine — Genesis 41*
+**Characters:** Bjorn Bigpaws, Herschel the Walrus  
+**Setting:** Frostpeak Valley, Supply Slope  
+**Theme:** Wise preparation
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Supply Slope** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Bjorn Bigpaws tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **hockey passing drill**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Herschel the Walrus handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Bjorn Bigpaws took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Joseph Saves for Famine — Genesis 41**.
+
+"Wait," Bjorn Bigpaws said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Herschel the Walrus called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Wise preparation**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Bjorn Bigpaws looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Bjorn Bigpaws slowed beside Herschel the Walrus and smiled. "The old stories are still alive," Bjorn Bigpaws said. "They just wear snow boots now." Herschel the Walrus laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Joseph Saves for Famine — Genesis 41
+- **Theme Check:** Wise preparation
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 27: The Grain-Barn Blizzard Plan**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Grain-Barn Blizzard Plan in Frostpeak Valley, Supply Slope, with Bjorn Bigpaws and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a hockey passing drill; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Joseph Saves for Famine — Genesis 41; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Supply Slope as friends gather for a hockey passing drill; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Joseph Saves for Famine — Genesis 41, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_28_the_basket_on_the_river_ice.md
+++ b/stories/story_28_the_basket_on_the_river_ice.md
@@ -1,0 +1,133 @@
+# Story 28: The Basket on the River Ice
+### *Inspired by Baby Moses — Exodus 2*
+**Characters:** Nora Snowmane, Mina Muskrat, Willa Wobble  
+**Setting:** Frostpeak Valley, Riverglass Channel  
+**Theme:** Gentle courage and protection
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Riverglass Channel** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Nora Snowmane tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowshoe trek**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Mina Muskrat handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Nora Snowmane took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Baby Moses — Exodus 2**.
+
+"Wait," Nora Snowmane said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Mina Muskrat called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Gentle courage and protection**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Nora Snowmane looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Nora Snowmane slowed beside Mina Muskrat and smiled. "The old stories are still alive," Nora Snowmane said. "They just wear snow boots now." Mina Muskrat laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Baby Moses — Exodus 2
+- **Theme Check:** Gentle courage and protection
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 28: The Basket on the River Ice**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Basket on the River Ice in Frostpeak Valley, Riverglass Channel, with Nora Snowmane and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowshoe trek; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Baby Moses — Exodus 2; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Riverglass Channel as friends gather for a snowshoe trek; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Baby Moses — Exodus 2, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_29_the_burning_berry_bush.md
+++ b/stories/story_29_the_burning_berry_bush.md
@@ -1,0 +1,133 @@
+# Story 29: The Burning Berry Bush
+### *Inspired by The Burning Bush — Exodus 3*
+**Characters:** Mo Mountain-Goat, Piper Paddlefoot  
+**Setting:** Frostpeak Valley, Ember Pine Grove  
+**Theme:** Listening and saying yes
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Ember Pine Grove** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Mo Mountain-Goat tightened a scarf, looked up at the gold-and-violet sunset haze, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **figure-skating showcase**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Piper Paddlefoot handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Mo Mountain-Goat took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **The Burning Bush — Exodus 3**.
+
+"Wait," Mo Mountain-Goat said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Piper Paddlefoot called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Listening and saying yes**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Mo Mountain-Goat looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Mo Mountain-Goat slowed beside Piper Paddlefoot and smiled. "The old stories are still alive," Mo Mountain-Goat said. "They just wear snow boots now." Piper Paddlefoot laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** The Burning Bush — Exodus 3
+- **Theme Check:** Listening and saying yes
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 29: The Burning Berry Bush**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Burning Berry Bush in Frostpeak Valley, Ember Pine Grove, with Mo Mountain-Goat and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a figure-skating showcase; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by The Burning Bush — Exodus 3; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Ember Pine Grove as friends gather for a figure-skating showcase; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from The Burning Bush — Exodus 3, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_30_frogs_on_the_halfpipe.md
+++ b/stories/story_30_frogs_on_the_halfpipe.md
@@ -1,0 +1,133 @@
+# Story 30: Frogs on the Halfpipe
+### *Inspired by The Plagues (soft retelling) — Exodus 7–12*
+**Characters:** Finnegan Flipsworth, Phineas Frog  
+**Setting:** Frostpeak Valley, Halfpipe Hollow  
+**Theme:** Let go of stubbornness
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Halfpipe Hollow** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Finnegan Flipsworth tightened a scarf, looked up at the powder-soft snowfall, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowboard relay**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Phineas Frog handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Finnegan Flipsworth took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **The Plagues (soft retelling) — Exodus 7–12**.
+
+"Wait," Finnegan Flipsworth said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Phineas Frog called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Let go of stubbornness**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Finnegan Flipsworth looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Finnegan Flipsworth slowed beside Phineas Frog and smiled. "The old stories are still alive," Finnegan Flipsworth said. "They just wear snow boots now." Phineas Frog laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** The Plagues (soft retelling) — Exodus 7–12
+- **Theme Check:** Let go of stubbornness
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 30: Frogs on the Halfpipe**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Frogs on the Halfpipe in Frostpeak Valley, Halfpipe Hollow, with Finnegan Flipsworth and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowboard relay; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by The Plagues (soft retelling) — Exodus 7–12; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Halfpipe Hollow as friends gather for a snowboard relay; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from The Plagues (soft retelling) — Exodus 7–12, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_31_manna_flakes_at_dawn.md
+++ b/stories/story_31_manna_flakes_at_dawn.md
@@ -1,0 +1,133 @@
+# Story 31: Manna Flakes at Dawn
+### *Inspired by Manna in the Wilderness — Exodus 16*
+**Characters:** Tovi Ptarmigan, Barnaby Beaksworth  
+**Setting:** Frostpeak Valley, Dawn Flats  
+**Theme:** Daily trust
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Dawn Flats** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Tovi Ptarmigan tightened a scarf, looked up at the sparkling moon frost, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **cross-country challenge**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Barnaby Beaksworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Tovi Ptarmigan took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Manna in the Wilderness — Exodus 16**.
+
+"Wait," Tovi Ptarmigan said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Barnaby Beaksworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Daily trust**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Tovi Ptarmigan looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Tovi Ptarmigan slowed beside Barnaby Beaksworth and smiled. "The old stories are still alive," Tovi Ptarmigan said. "They just wear snow boots now." Barnaby Beaksworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Manna in the Wilderness — Exodus 16
+- **Theme Check:** Daily trust
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 31: Manna Flakes at Dawn**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Manna Flakes at Dawn in Frostpeak Valley, Dawn Flats, with Tovi Ptarmigan and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a cross-country challenge; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Manna in the Wilderness — Exodus 16; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Dawn Flats as friends gather for a cross-country challenge; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Manna in the Wilderness — Exodus 16, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_32_ten_snowy_signposts.md
+++ b/stories/story_32_ten_snowy_signposts.md
@@ -1,0 +1,133 @@
+# Story 32: Ten Snowy Signposts
+### *Inspired by The Ten Commandments — Exodus 20*
+**Characters:** Granite Ram, Bjorn Bigpaws  
+**Setting:** Frostpeak Valley, Summit Switchbacks  
+**Theme:** Boundaries that protect
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Summit Switchbacks** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Granite Ram tightened a scarf, looked up at the gentle aurora glow, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **curling scramble**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Bjorn Bigpaws handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Granite Ram took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **The Ten Commandments — Exodus 20**.
+
+"Wait," Granite Ram said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Bjorn Bigpaws called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Boundaries that protect**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Granite Ram looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Granite Ram slowed beside Bjorn Bigpaws and smiled. "The old stories are still alive," Granite Ram said. "They just wear snow boots now." Bjorn Bigpaws laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** The Ten Commandments — Exodus 20
+- **Theme Check:** Boundaries that protect
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 32: Ten Snowy Signposts**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Ten Snowy Signposts in Frostpeak Valley, Summit Switchbacks, with Granite Ram and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a curling scramble; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by The Ten Commandments — Exodus 20; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Summit Switchbacks as friends gather for a curling scramble; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from The Ten Commandments — Exodus 20, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_33_the_golden_snow_calf_oops.md
+++ b/stories/story_33_the_golden_snow_calf_oops.md
@@ -1,0 +1,133 @@
+# Story 33: The Golden Snow-Calf Oops
+### *Inspired by The Golden Calf — Exodus 32*
+**Characters:** Glint Magpie, Cleo Coldwater  
+**Setting:** Frostpeak Valley, Festival Plaza  
+**Theme:** Don't trade truth for glitter
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Festival Plaza** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Glint Magpie tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **biathlon loop**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Cleo Coldwater handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Glint Magpie took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **The Golden Calf — Exodus 32**.
+
+"Wait," Glint Magpie said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Cleo Coldwater called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Don't trade truth for glitter**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Glint Magpie looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Glint Magpie slowed beside Cleo Coldwater and smiled. "The old stories are still alive," Glint Magpie said. "They just wear snow boots now." Cleo Coldwater laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** The Golden Calf — Exodus 32
+- **Theme Check:** Don't trade truth for glitter
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 33: The Golden Snow-Calf Oops**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Golden Snow-Calf Oops in Frostpeak Valley, Festival Plaza, with Glint Magpie and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a biathlon loop; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by The Golden Calf — Exodus 32; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Festival Plaza as friends gather for a biathlon loop; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from The Golden Calf — Exodus 32, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_34_rahabs_scarlet_ski_rope.md
+++ b/stories/story_34_rahabs_scarlet_ski_rope.md
@@ -1,0 +1,133 @@
+# Story 34: Rahab's Scarlet Ski Rope
+### *Inspired by Rahab and the Scarlet Cord — Joshua 2*
+**Characters:** Raya Snow-Fox, Aurora Frostholm  
+**Setting:** Frostpeak Valley, Wallside Cliffs  
+**Theme:** Brave hospitality
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Wallside Cliffs** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Raya Snow-Fox tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ski slalom**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Aurora Frostholm handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Raya Snow-Fox took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Rahab and the Scarlet Cord — Joshua 2**.
+
+"Wait," Raya Snow-Fox said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Aurora Frostholm called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Brave hospitality**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Raya Snow-Fox looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Raya Snow-Fox slowed beside Aurora Frostholm and smiled. "The old stories are still alive," Raya Snow-Fox said. "They just wear snow boots now." Aurora Frostholm laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Rahab and the Scarlet Cord — Joshua 2
+- **Theme Check:** Brave hospitality
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 34: Rahab's Scarlet Ski Rope**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Rahab's Scarlet Ski Rope in Frostpeak Valley, Wallside Cliffs, with Raya Snow-Fox and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ski slalom; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Rahab and the Scarlet Cord — Joshua 2; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Wallside Cliffs as friends gather for a ski slalom; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Rahab and the Scarlet Cord — Joshua 2, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_35_the_trumpets_of_jericho_jump.md
+++ b/stories/story_35_the_trumpets_of_jericho_jump.md
@@ -1,0 +1,133 @@
+# Story 35: The Trumpets of Jericho Jump
+### *Inspired by Jericho — Joshua 6*
+**Characters:** Jory Ibex, Barnaby Beaksworth  
+**Setting:** Frostpeak Valley, Jericho Jump Arena  
+**Theme:** Trusting unusual instructions
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Jericho Jump Arena** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Jory Ibex tightened a scarf, looked up at the gold-and-violet sunset haze, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ice-dance parade**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Barnaby Beaksworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Jory Ibex took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Jericho — Joshua 6**.
+
+"Wait," Jory Ibex said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Barnaby Beaksworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Trusting unusual instructions**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Jory Ibex looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Jory Ibex slowed beside Barnaby Beaksworth and smiled. "The old stories are still alive," Jory Ibex said. "They just wear snow boots now." Barnaby Beaksworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Jericho — Joshua 6
+- **Theme Check:** Trusting unusual instructions
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 35: The Trumpets of Jericho Jump**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Trumpets of Jericho Jump in Frostpeak Valley, Jericho Jump Arena, with Jory Ibex and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ice-dance parade; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Jericho — Joshua 6; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Jericho Jump Arena as friends gather for a ice-dance parade; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Jericho — Joshua 6, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_36_gideons_tiny_team_tumble.md
+++ b/stories/story_36_gideons_tiny_team_tumble.md
@@ -1,0 +1,133 @@
+# Story 36: Gideon's Tiny Team Tumble
+### *Inspired by Gideon's Small Army — Judges 7*
+**Characters:** Gideon Goose, Willa Wobble  
+**Setting:** Frostpeak Valley, Moon Basin  
+**Theme:** God can use small teams
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Moon Basin** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Gideon Goose tightened a scarf, looked up at the powder-soft snowfall, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **sled sprint**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Willa Wobble handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Gideon Goose took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Gideon's Small Army — Judges 7**.
+
+"Wait," Gideon Goose said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Willa Wobble called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **God can use small teams**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Gideon Goose looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Gideon Goose slowed beside Willa Wobble and smiled. "The old stories are still alive," Gideon Goose said. "They just wear snow boots now." Willa Wobble laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Gideon's Small Army — Judges 7
+- **Theme Check:** God can use small teams
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 36: Gideon's Tiny Team Tumble**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Gideon's Tiny Team Tumble in Frostpeak Valley, Moon Basin, with Gideon Goose and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a sled sprint; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Gideon's Small Army — Judges 7; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Moon Basin as friends gather for a sled sprint; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Gideon's Small Army — Judges 7, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_37_deborahs_drumline_downhill.md
+++ b/stories/story_37_deborahs_drumline_downhill.md
@@ -1,0 +1,133 @@
+# Story 37: Deborah's Drumline Downhill
+### *Inspired by Deborah Leads Israel — Judges 4*
+**Characters:** Deborah Dove, Nora Snowmane  
+**Setting:** Frostpeak Valley, Victory Ridge  
+**Theme:** Wise leadership
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Victory Ridge** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Deborah Dove tightened a scarf, looked up at the sparkling moon frost, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **hockey passing drill**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Nora Snowmane handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Deborah Dove took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Deborah Leads Israel — Judges 4**.
+
+"Wait," Deborah Dove said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Nora Snowmane called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Wise leadership**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Deborah Dove looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Deborah Dove slowed beside Nora Snowmane and smiled. "The old stories are still alive," Deborah Dove said. "They just wear snow boots now." Nora Snowmane laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Deborah Leads Israel — Judges 4
+- **Theme Check:** Wise leadership
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 37: Deborah's Drumline Downhill**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Deborah's Drumline Downhill in Frostpeak Valley, Victory Ridge, with Deborah Dove and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a hockey passing drill; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Deborah Leads Israel — Judges 4; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Victory Ridge as friends gather for a hockey passing drill; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Deborah Leads Israel — Judges 4, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_38_ruth_and_the_barley_blizzard.md
+++ b/stories/story_38_ruth_and_the_barley_blizzard.md
@@ -1,0 +1,133 @@
+# Story 38: Ruth and the Barley Blizzard
+### *Inspired by Ruth — Ruth 1–4*
+**Characters:** Ruthie Raccoon, Barnaby Beaksworth  
+**Setting:** Frostpeak Valley, Harvest Hollow  
+**Theme:** Loyal love
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Harvest Hollow** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Ruthie Raccoon tightened a scarf, looked up at the gentle aurora glow, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowshoe trek**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Barnaby Beaksworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Ruthie Raccoon took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Ruth — Ruth 1–4**.
+
+"Wait," Ruthie Raccoon said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Barnaby Beaksworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Loyal love**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Ruthie Raccoon looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Ruthie Raccoon slowed beside Barnaby Beaksworth and smiled. "The old stories are still alive," Ruthie Raccoon said. "They just wear snow boots now." Barnaby Beaksworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Ruth — Ruth 1–4
+- **Theme Check:** Loyal love
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 38: Ruth and the Barley Blizzard**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Ruth and the Barley Blizzard in Frostpeak Valley, Harvest Hollow, with Ruthie Raccoon and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowshoe trek; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Ruth — Ruth 1–4; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Harvest Hollow as friends gather for a snowshoe trek; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Ruth — Ruth 1–4, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_39_hannahs_quiet_rink_prayer.md
+++ b/stories/story_39_hannahs_quiet_rink_prayer.md
@@ -1,0 +1,133 @@
+# Story 39: Hannah's Quiet Rink Prayer
+### *Inspired by Hannah's Prayer — 1 Samuel 1*
+**Characters:** Hannah Heron, Willa Wobble  
+**Setting:** Frostpeak Valley, Silent Rink  
+**Theme:** Honest prayer
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Silent Rink** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Hannah Heron tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **figure-skating showcase**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Willa Wobble handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Hannah Heron took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Hannah's Prayer — 1 Samuel 1**.
+
+"Wait," Hannah Heron said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Willa Wobble called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Honest prayer**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Hannah Heron looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Hannah Heron slowed beside Willa Wobble and smiled. "The old stories are still alive," Hannah Heron said. "They just wear snow boots now." Willa Wobble laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Hannah's Prayer — 1 Samuel 1
+- **Theme Check:** Honest prayer
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 39: Hannah's Quiet Rink Prayer**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Hannah's Quiet Rink Prayer in Frostpeak Valley, Silent Rink, with Hannah Heron and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a figure-skating showcase; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Hannah's Prayer — 1 Samuel 1; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Silent Rink as friends gather for a figure-skating showcase; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Hannah's Prayer — 1 Samuel 1, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_40_the_little_lantern_king.md
+++ b/stories/story_40_the_little_lantern_king.md
@@ -1,0 +1,133 @@
+# Story 40: The Little Lantern King
+### *Inspired by Samuel Anoints David — 1 Samuel 16*
+**Characters:** Davy Dormouse, Bjorn Bigpaws  
+**Setting:** Frostpeak Valley, Lantern Lodge  
+**Theme:** Heart over appearance
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Lantern Lodge** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Davy Dormouse tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowboard relay**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Bjorn Bigpaws handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Davy Dormouse took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Samuel Anoints David — 1 Samuel 16**.
+
+"Wait," Davy Dormouse said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Bjorn Bigpaws called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Heart over appearance**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Davy Dormouse looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Davy Dormouse slowed beside Bjorn Bigpaws and smiled. "The old stories are still alive," Davy Dormouse said. "They just wear snow boots now." Bjorn Bigpaws laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Samuel Anoints David — 1 Samuel 16
+- **Theme Check:** Heart over appearance
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 40: The Little Lantern King**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Little Lantern King in Frostpeak Valley, Lantern Lodge, with Davy Dormouse and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowboard relay; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Samuel Anoints David — 1 Samuel 16; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Lantern Lodge as friends gather for a snowboard relay; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Samuel Anoints David — 1 Samuel 16, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_41_the_harp_on_ice.md
+++ b/stories/story_41_the_harp_on_ice.md
@@ -1,0 +1,133 @@
+# Story 41: The Harp on Ice
+### *Inspired by David Soothes Saul — 1 Samuel 16:23*
+**Characters:** Ari Arctic-Fox, Magnus Meltsworth  
+**Setting:** Frostpeak Valley, Echo Lake  
+**Theme:** Gentle music calms
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Echo Lake** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Ari Arctic-Fox tightened a scarf, looked up at the gold-and-violet sunset haze, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **cross-country challenge**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Magnus Meltsworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Ari Arctic-Fox took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **David Soothes Saul — 1 Samuel 16:23**.
+
+"Wait," Ari Arctic-Fox said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Magnus Meltsworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Gentle music calms**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Ari Arctic-Fox looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Ari Arctic-Fox slowed beside Magnus Meltsworth and smiled. "The old stories are still alive," Ari Arctic-Fox said. "They just wear snow boots now." Magnus Meltsworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** David Soothes Saul — 1 Samuel 16:23
+- **Theme Check:** Gentle music calms
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 41: The Harp on Ice**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Harp on Ice in Frostpeak Valley, Echo Lake, with Ari Arctic-Fox and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a cross-country challenge; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by David Soothes Saul — 1 Samuel 16:23; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Echo Lake as friends gather for a cross-country challenge; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from David Soothes Saul — 1 Samuel 16:23, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_42_ravens_and_snack_drop.md
+++ b/stories/story_42_ravens_and_snack_drop.md
@@ -1,0 +1,133 @@
+# Story 42: Ravens and the Snack Drop
+### *Inspired by Elijah Fed by Ravens — 1 Kings 17*
+**Characters:** Eli Elk, Nibbles & Splash  
+**Setting:** Frostpeak Valley, Raven Ridge  
+**Theme:** Provision in lonely seasons
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Raven Ridge** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Eli Elk tightened a scarf, looked up at the powder-soft snowfall, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **curling scramble**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Nibbles & Splash handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Eli Elk took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Elijah Fed by Ravens — 1 Kings 17**.
+
+"Wait," Eli Elk said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Nibbles & Splash called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Provision in lonely seasons**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Eli Elk looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Eli Elk slowed beside Nibbles & Splash and smiled. "The old stories are still alive," Eli Elk said. "They just wear snow boots now." Nibbles & Splash laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Elijah Fed by Ravens — 1 Kings 17
+- **Theme Check:** Provision in lonely seasons
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 42: Ravens and the Snack Drop**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Ravens and the Snack Drop in Frostpeak Valley, Raven Ridge, with Eli Elk and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a curling scramble; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Elijah Fed by Ravens — 1 Kings 17; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Raven Ridge as friends gather for a curling scramble; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Elijah Fed by Ravens — 1 Kings 17, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_43_the_fire_on_frost_mountain.md
+++ b/stories/story_43_the_fire_on_frost_mountain.md
@@ -1,0 +1,133 @@
+# Story 43: The Fire on Frost Mountain
+### *Inspired by Elijah on Mount Carmel — 1 Kings 18*
+**Characters:** Kara Caribou, Cleo Coldwater  
+**Setting:** Frostpeak Valley, Frost Mountain Bowl  
+**Theme:** Truth over showmanship
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Frost Mountain Bowl** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Kara Caribou tightened a scarf, looked up at the sparkling moon frost, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **biathlon loop**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Cleo Coldwater handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Kara Caribou took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Elijah on Mount Carmel — 1 Kings 18**.
+
+"Wait," Kara Caribou said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Cleo Coldwater called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Truth over showmanship**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Kara Caribou looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Kara Caribou slowed beside Cleo Coldwater and smiled. "The old stories are still alive," Kara Caribou said. "They just wear snow boots now." Cleo Coldwater laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Elijah on Mount Carmel — 1 Kings 18
+- **Theme Check:** Truth over showmanship
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 43: The Fire on Frost Mountain**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Fire on Frost Mountain in Frostpeak Valley, Frost Mountain Bowl, with Kara Caribou and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a biathlon loop; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Elijah on Mount Carmel — 1 Kings 18; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Frost Mountain Bowl as friends gather for a biathlon loop; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Elijah on Mount Carmel — 1 Kings 18, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_44_the_whisper_in_the_snow_cave.md
+++ b/stories/story_44_the_whisper_in_the_snow_cave.md
@@ -1,0 +1,133 @@
+# Story 44: The Whisper in the Snow Cave
+### *Inspired by Still Small Voice — 1 Kings 19*
+**Characters:** Elia Ermine, Nora Snowmane  
+**Setting:** Frostpeak Valley, Snow Cave Pass  
+**Theme:** Listening in quiet
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Snow Cave Pass** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Elia Ermine tightened a scarf, looked up at the gentle aurora glow, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ski slalom**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Nora Snowmane handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Elia Ermine took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Still Small Voice — 1 Kings 19**.
+
+"Wait," Elia Ermine said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Nora Snowmane called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Listening in quiet**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Elia Ermine looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Elia Ermine slowed beside Nora Snowmane and smiled. "The old stories are still alive," Elia Ermine said. "They just wear snow boots now." Nora Snowmane laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Still Small Voice — 1 Kings 19
+- **Theme Check:** Listening in quiet
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 44: The Whisper in the Snow Cave**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Whisper in the Snow Cave in Frostpeak Valley, Snow Cave Pass, with Elia Ermine and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ski slalom; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Still Small Voice — 1 Kings 19; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Snow Cave Pass as friends gather for a ski slalom; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Still Small Voice — 1 Kings 19, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_45_naamans_seven_splashes.md
+++ b/stories/story_45_naamans_seven_splashes.md
@@ -1,0 +1,133 @@
+# Story 45: Naaman's Seven Splashes
+### *Inspired by Naaman Healed — 2 Kings 5*
+**Characters:** Nemo Narwhal, Magnus Meltsworth  
+**Setting:** Frostpeak Valley, Jordan Pool  
+**Theme:** Humility heals
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Jordan Pool** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Nemo Narwhal tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ice-dance parade**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Magnus Meltsworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Nemo Narwhal took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Naaman Healed — 2 Kings 5**.
+
+"Wait," Nemo Narwhal said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Magnus Meltsworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Humility heals**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Nemo Narwhal looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Nemo Narwhal slowed beside Magnus Meltsworth and smiled. "The old stories are still alive," Nemo Narwhal said. "They just wear snow boots now." Magnus Meltsworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Naaman Healed — 2 Kings 5
+- **Theme Check:** Humility heals
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 45: Naaman's Seven Splashes**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Naaman's Seven Splashes in Frostpeak Valley, Jordan Pool, with Nemo Narwhal and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ice-dance parade; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Naaman Healed — 2 Kings 5; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Jordan Pool as friends gather for a ice-dance parade; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Naaman Healed — 2 Kings 5, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_46_the_ax_that_floated.md
+++ b/stories/story_46_the_ax_that_floated.md
@@ -1,0 +1,133 @@
+# Story 46: The Axe That Floated
+### *Inspired by Floating Axe Head — 2 Kings 6*
+**Characters:** Axel Beaver, Piper Paddlefoot  
+**Setting:** Frostpeak Valley, Workshop Pond  
+**Theme:** God cares about little losses
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Workshop Pond** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Axel Beaver tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **sled sprint**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Piper Paddlefoot handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Axel Beaver took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Floating Axe Head — 2 Kings 6**.
+
+"Wait," Axel Beaver said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Piper Paddlefoot called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **God cares about little losses**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Axel Beaver looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Axel Beaver slowed beside Piper Paddlefoot and smiled. "The old stories are still alive," Axel Beaver said. "They just wear snow boots now." Piper Paddlefoot laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Floating Axe Head — 2 Kings 6
+- **Theme Check:** God cares about little losses
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 46: The Axe That Floated**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Axe That Floated in Frostpeak Valley, Workshop Pond, with Axel Beaver and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a sled sprint; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Floating Axe Head — 2 Kings 6; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Workshop Pond as friends gather for a sled sprint; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Floating Axe Head — 2 Kings 6, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_47_esthers_brave_banquet.md
+++ b/stories/story_47_esthers_brave_banquet.md
@@ -1,0 +1,133 @@
+# Story 47: Esther's Brave Banquet
+### *Inspired by Esther's Courage — Esther 4–7*
+**Characters:** Esti Stoat, Aurora Frostholm  
+**Setting:** Frostpeak Valley, Winter Palace  
+**Theme:** Courage for others
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Winter Palace** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Esti Stoat tightened a scarf, looked up at the gold-and-violet sunset haze, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **hockey passing drill**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Aurora Frostholm handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Esti Stoat took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Esther's Courage — Esther 4–7**.
+
+"Wait," Esti Stoat said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Aurora Frostholm called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Courage for others**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Esti Stoat looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Esti Stoat slowed beside Aurora Frostholm and smiled. "The old stories are still alive," Esti Stoat said. "They just wear snow boots now." Aurora Frostholm laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Esther's Courage — Esther 4–7
+- **Theme Check:** Courage for others
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 47: Esther's Brave Banquet**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Esther's Brave Banquet in Frostpeak Valley, Winter Palace, with Esti Stoat and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a hockey passing drill; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Esther's Courage — Esther 4–7; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Winter Palace as friends gather for a hockey passing drill; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Esther's Courage — Esther 4–7, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_48_job_and_the_long_snow_night.md
+++ b/stories/story_48_job_and_the_long_snow_night.md
@@ -1,0 +1,133 @@
+# Story 48: Job and the Long Snow Night
+### *Inspired by Job — Job 1–42*
+**Characters:** Jobi Yak, Nora Snowmane  
+**Setting:** Frostpeak Valley, Stillwind Camp  
+**Theme:** Hope through sadness
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Stillwind Camp** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Jobi Yak tightened a scarf, looked up at the powder-soft snowfall, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowshoe trek**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Nora Snowmane handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Jobi Yak took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Job — Job 1–42**.
+
+"Wait," Jobi Yak said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Nora Snowmane called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Hope through sadness**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Jobi Yak looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Jobi Yak slowed beside Nora Snowmane and smiled. "The old stories are still alive," Jobi Yak said. "They just wear snow boots now." Nora Snowmane laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Job — Job 1–42
+- **Theme Check:** Hope through sadness
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 48: Job and the Long Snow Night**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Job and the Long Snow Night in Frostpeak Valley, Stillwind Camp, with Jobi Yak and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowshoe trek; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Job — Job 1–42; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Stillwind Camp as friends gather for a snowshoe trek; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Job — Job 1–42, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_49_the_psalm_song_lift.md
+++ b/stories/story_49_the_psalm_song_lift.md
@@ -1,0 +1,133 @@
+# Story 49: The Psalm-Song Lift
+### *Inspired by Psalms*
+**Characters:** Kingfisher Choir, Barnaby Beaksworth  
+**Setting:** Frostpeak Valley, Lift Line Ridge  
+**Theme:** Praise in every mood
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Lift Line Ridge** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Kingfisher Choir tightened a scarf, looked up at the sparkling moon frost, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **figure-skating showcase**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Barnaby Beaksworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Kingfisher Choir took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Psalms**.
+
+"Wait," Kingfisher Choir said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Barnaby Beaksworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Praise in every mood**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Kingfisher Choir looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Kingfisher Choir slowed beside Barnaby Beaksworth and smiled. "The old stories are still alive," Kingfisher Choir said. "They just wear snow boots now." Barnaby Beaksworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Psalms
+- **Theme Check:** Praise in every mood
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 49: The Psalm-Song Lift**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Psalm-Song Lift in Frostpeak Valley, Lift Line Ridge, with Kingfisher Choir and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a figure-skating showcase; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Psalms; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Lift Line Ridge as friends gather for a figure-skating showcase; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Psalms, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_50_king_sols_wisdom_race.md
+++ b/stories/story_50_king_sols_wisdom_race.md
@@ -1,0 +1,133 @@
+# Story 50: King Sol's Wisdom Race
+### *Inspired by Solomon's Wisdom — 1 Kings 3*
+**Characters:** Sol Snowy-Owl, Willa Wobble  
+**Setting:** Frostpeak Valley, Judge's Oval  
+**Theme:** Wise choices
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Judge's Oval** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Sol Snowy-Owl tightened a scarf, looked up at the gentle aurora glow, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowboard relay**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Willa Wobble handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Sol Snowy-Owl took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Solomon's Wisdom — 1 Kings 3**.
+
+"Wait," Sol Snowy-Owl said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Willa Wobble called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Wise choices**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Sol Snowy-Owl looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Sol Snowy-Owl slowed beside Willa Wobble and smiled. "The old stories are still alive," Sol Snowy-Owl said. "They just wear snow boots now." Willa Wobble laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Solomon's Wisdom — 1 Kings 3
+- **Theme Check:** Wise choices
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 50: King Sol's Wisdom Race**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> King Sol's Wisdom Race in Frostpeak Valley, Judge's Oval, with Sol Snowy-Owl and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowboard relay; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Solomon's Wisdom — 1 Kings 3; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Judge's Oval as friends gather for a snowboard relay; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Solomon's Wisdom — 1 Kings 3, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_51_the_snow_queen_of_sheba.md
+++ b/stories/story_51_the_snow_queen_of_sheba.md
@@ -1,0 +1,133 @@
+# Story 51: The Snow Queen of Sheba
+### *Inspired by Queen of Sheba Visits Solomon — 1 Kings 10*
+**Characters:** Sheba Seal, Cleo Coldwater  
+**Setting:** Frostpeak Valley, Crystal Court  
+**Theme:** Curiosity and learning
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Crystal Court** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Sheba Seal tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **cross-country challenge**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Cleo Coldwater handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Sheba Seal took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Queen of Sheba Visits Solomon — 1 Kings 10**.
+
+"Wait," Sheba Seal said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Cleo Coldwater called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Curiosity and learning**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Sheba Seal looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Sheba Seal slowed beside Cleo Coldwater and smiled. "The old stories are still alive," Sheba Seal said. "They just wear snow boots now." Cleo Coldwater laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Queen of Sheba Visits Solomon — 1 Kings 10
+- **Theme Check:** Curiosity and learning
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 51: The Snow Queen of Sheba**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Snow Queen of Sheba in Frostpeak Valley, Crystal Court, with Sheba Seal and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a cross-country challenge; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Queen of Sheba Visits Solomon — 1 Kings 10; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Crystal Court as friends gather for a cross-country challenge; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Queen of Sheba Visits Solomon — 1 Kings 10, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_52_the_writing_on_the_ice_wall.md
+++ b/stories/story_52_the_writing_on_the_ice_wall.md
@@ -1,0 +1,133 @@
+# Story 52: The Writing on the Ice Wall
+### *Inspired by Writing on the Wall — Daniel 5*
+**Characters:** Bela Bear, Bjorn Bigpaws  
+**Setting:** Frostpeak Valley, Ice Palace  
+**Theme:** Pride has limits
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Ice Palace** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Bela Bear tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **curling scramble**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Bjorn Bigpaws handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Bela Bear took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Writing on the Wall — Daniel 5**.
+
+"Wait," Bela Bear said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Bjorn Bigpaws called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Pride has limits**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Bela Bear looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Bela Bear slowed beside Bjorn Bigpaws and smiled. "The old stories are still alive," Bela Bear said. "They just wear snow boots now." Bjorn Bigpaws laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Writing on the Wall — Daniel 5
+- **Theme Check:** Pride has limits
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 52: The Writing on the Ice Wall**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Writing on the Ice Wall in Frostpeak Valley, Ice Palace, with Bela Bear and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a curling scramble; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Writing on the Wall — Daniel 5; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Ice Palace as friends gather for a curling scramble; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Writing on the Wall — Daniel 5, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_53_shadrachs_snowproof_suits.md
+++ b/stories/story_53_shadrachs_snowproof_suits.md
@@ -1,0 +1,133 @@
+# Story 53: Shadrach's Snowproof Suits
+### *Inspired by Fiery Furnace — Daniel 3*
+**Characters:** Shai Sheep, Finnegan Flipsworth  
+**Setting:** Frostpeak Valley, Heat Dome Halfpipe  
+**Theme:** Faithful friendship
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Heat Dome Halfpipe** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Shai Sheep tightened a scarf, looked up at the gold-and-violet sunset haze, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **biathlon loop**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Finnegan Flipsworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Shai Sheep took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Fiery Furnace — Daniel 3**.
+
+"Wait," Shai Sheep said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Finnegan Flipsworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Faithful friendship**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Shai Sheep looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Shai Sheep slowed beside Finnegan Flipsworth and smiled. "The old stories are still alive," Shai Sheep said. "They just wear snow boots now." Finnegan Flipsworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Fiery Furnace — Daniel 3
+- **Theme Check:** Faithful friendship
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 53: Shadrach's Snowproof Suits**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Shadrach's Snowproof Suits in Frostpeak Valley, Heat Dome Halfpipe, with Shai Sheep and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a biathlon loop; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Fiery Furnace — Daniel 3; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Heat Dome Halfpipe as friends gather for a biathlon loop; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Fiery Furnace — Daniel 3, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_54_the_valley_of_dancing_bones.md
+++ b/stories/story_54_the_valley_of_dancing_bones.md
@@ -1,0 +1,133 @@
+# Story 54: The Valley of Dancing Bones
+### *Inspired by Valley of Dry Bones — Ezekiel 37*
+**Characters:** Zeke Finch, Cleo Coldwater  
+**Setting:** Frostpeak Valley, Rattle Valley  
+**Theme:** Hope for dry places
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Rattle Valley** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Zeke Finch tightened a scarf, looked up at the powder-soft snowfall, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ski slalom**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Cleo Coldwater handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Zeke Finch took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Valley of Dry Bones — Ezekiel 37**.
+
+"Wait," Zeke Finch said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Cleo Coldwater called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Hope for dry places**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Zeke Finch looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Zeke Finch slowed beside Cleo Coldwater and smiled. "The old stories are still alive," Zeke Finch said. "They just wear snow boots now." Cleo Coldwater laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Valley of Dry Bones — Ezekiel 37
+- **Theme Check:** Hope for dry places
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 54: The Valley of Dancing Bones**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Valley of Dancing Bones in Frostpeak Valley, Rattle Valley, with Zeke Finch and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ski slalom; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Valley of Dry Bones — Ezekiel 37; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Rattle Valley as friends gather for a ski slalom; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Valley of Dry Bones — Ezekiel 37, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_55_the_census_sled_journey.md
+++ b/stories/story_55_the_census_sled_journey.md
@@ -1,0 +1,133 @@
+# Story 55: The Census Sled Journey
+### *Inspired by Journey to Bethlehem — Luke 2:1–5*
+**Characters:** Miri Marmot, Jo Moose, Mary Moose  
+**Setting:** Frostpeak Valley, Bethlehem Bend  
+**Theme:** Faithful travel
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Bethlehem Bend** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Miri Marmot tightened a scarf, looked up at the sparkling moon frost, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ice-dance parade**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Jo Moose handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Miri Marmot took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Journey to Bethlehem — Luke 2:1–5**.
+
+"Wait," Miri Marmot said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Jo Moose called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Faithful travel**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Miri Marmot looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Miri Marmot slowed beside Jo Moose and smiled. "The old stories are still alive," Miri Marmot said. "They just wear snow boots now." Jo Moose laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Journey to Bethlehem — Luke 2:1–5
+- **Theme Check:** Faithful travel
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 55: The Census Sled Journey**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Census Sled Journey in Frostpeak Valley, Bethlehem Bend, with Miri Marmot and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ice-dance parade; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Journey to Bethlehem — Luke 2:1–5; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Bethlehem Bend as friends gather for a ice-dance parade; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Journey to Bethlehem — Luke 2:1–5, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_56_the_stable_by_the_ski_lodge.md
+++ b/stories/story_56_the_stable_by_the_ski_lodge.md
@@ -1,0 +1,133 @@
+# Story 56: The Stable by the Ski Lodge
+### *Inspired by Birth of Jesus — Luke 2:6–20*
+**Characters:** Jo and Mary Moose, Barnaby Beaksworth  
+**Setting:** Frostpeak Valley, Lodge Stable  
+**Theme:** Humble joy
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Lodge Stable** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Jo and Mary Moose tightened a scarf, looked up at the gentle aurora glow, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **sled sprint**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Barnaby Beaksworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Jo and Mary Moose took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Birth of Jesus — Luke 2:6–20**.
+
+"Wait," Jo and Mary Moose said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Barnaby Beaksworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Humble joy**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Jo and Mary Moose looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Jo and Mary Moose slowed beside Barnaby Beaksworth and smiled. "The old stories are still alive," Jo and Mary Moose said. "They just wear snow boots now." Barnaby Beaksworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Birth of Jesus — Luke 2:6–20
+- **Theme Check:** Humble joy
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 56: The Stable by the Ski Lodge**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Stable by the Ski Lodge in Frostpeak Valley, Lodge Stable, with Jo and Mary Moose and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a sled sprint; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Birth of Jesus — Luke 2:6–20; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Lodge Stable as friends gather for a sled sprint; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Birth of Jesus — Luke 2:6–20, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_57_shepherds_on_the_night_shift.md
+++ b/stories/story_57_shepherds_on_the_night_shift.md
@@ -1,0 +1,133 @@
+# Story 57: Shepherds on the Night Shift
+### *Inspired by Shepherds and Angels — Luke 2*
+**Characters:** Shep Seal, Aurora Frostholm  
+**Setting:** Frostpeak Valley, Nightwatch Hills  
+**Theme:** Good news for everyone
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Nightwatch Hills** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Shep Seal tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **hockey passing drill**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Aurora Frostholm handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Shep Seal took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Shepherds and Angels — Luke 2**.
+
+"Wait," Shep Seal said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Aurora Frostholm called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Good news for everyone**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Shep Seal looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Shep Seal slowed beside Aurora Frostholm and smiled. "The old stories are still alive," Shep Seal said. "They just wear snow boots now." Aurora Frostholm laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Shepherds and Angels — Luke 2
+- **Theme Check:** Good news for everyone
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 57: Shepherds on the Night Shift**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Shepherds on the Night Shift in Frostpeak Valley, Nightwatch Hills, with Shep Seal and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a hockey passing drill; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Shepherds and Angels — Luke 2; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Nightwatch Hills as friends gather for a hockey passing drill; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Shepherds and Angels — Luke 2, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_58_the_stargazer_snow_kings.md
+++ b/stories/story_58_the_stargazer_snow_kings.md
@@ -1,0 +1,133 @@
+# Story 58: The Stargazer Snow Kings
+### *Inspired by Wise Men Follow the Star — Matthew 2*
+**Characters:** Magi Marmots, Captain Prism  
+**Setting:** Frostpeak Valley, Star Dune  
+**Theme:** Seeking light
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Star Dune** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Magi Marmots tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowshoe trek**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Captain Prism handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Magi Marmots took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Wise Men Follow the Star — Matthew 2**.
+
+"Wait," Magi Marmots said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Captain Prism called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Seeking light**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Magi Marmots looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Magi Marmots slowed beside Captain Prism and smiled. "The old stories are still alive," Magi Marmots said. "They just wear snow boots now." Captain Prism laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Wise Men Follow the Star — Matthew 2
+- **Theme Check:** Seeking light
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 58: The Stargazer Snow Kings**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Stargazer Snow Kings in Frostpeak Valley, Star Dune, with Magi Marmots and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowshoe trek; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Wise Men Follow the Star — Matthew 2; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Star Dune as friends gather for a snowshoe trek; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Wise Men Follow the Star — Matthew 2, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_59_the_voice_by_frozen_river.md
+++ b/stories/story_59_the_voice_by_frozen_river.md
@@ -1,0 +1,133 @@
+# Story 59: The Voice by Frozen River
+### *Inspired by John the Baptist — Matthew 3*
+**Characters:** Juno Jay, Piper Paddlefoot  
+**Setting:** Frostpeak Valley, River Reeds  
+**Theme:** Fresh starts
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **River Reeds** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Juno Jay tightened a scarf, looked up at the gold-and-violet sunset haze, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **figure-skating showcase**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Piper Paddlefoot handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Juno Jay took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **John the Baptist — Matthew 3**.
+
+"Wait," Juno Jay said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Piper Paddlefoot called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Fresh starts**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Juno Jay looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Juno Jay slowed beside Piper Paddlefoot and smiled. "The old stories are still alive," Juno Jay said. "They just wear snow boots now." Piper Paddlefoot laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** John the Baptist — Matthew 3
+- **Theme Check:** Fresh starts
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 59: The Voice by Frozen River**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Voice by Frozen River in Frostpeak Valley, River Reeds, with Juno Jay and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a figure-skating showcase; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by John the Baptist — Matthew 3; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, River Reeds as friends gather for a figure-skating showcase; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from John the Baptist — Matthew 3, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_60_forty_days_on_windy_peak.md
+++ b/stories/story_60_forty_days_on_windy_peak.md
@@ -1,0 +1,133 @@
+# Story 60: Forty Days on Windy Peak
+### *Inspired by Temptation in the Wilderness — Matthew 4*
+**Characters:** Theo Tundra-Wolf, Willa Wobble  
+**Setting:** Frostpeak Valley, Windy Peak  
+**Theme:** Choosing what is right
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Windy Peak** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Theo Tundra-Wolf tightened a scarf, looked up at the powder-soft snowfall, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowboard relay**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Willa Wobble handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Theo Tundra-Wolf took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Temptation in the Wilderness — Matthew 4**.
+
+"Wait," Theo Tundra-Wolf said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Willa Wobble called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Choosing what is right**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Theo Tundra-Wolf looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Theo Tundra-Wolf slowed beside Willa Wobble and smiled. "The old stories are still alive," Theo Tundra-Wolf said. "They just wear snow boots now." Willa Wobble laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Temptation in the Wilderness — Matthew 4
+- **Theme Check:** Choosing what is right
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 60: Forty Days on Windy Peak**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Forty Days on Windy Peak in Frostpeak Valley, Windy Peak, with Theo Tundra-Wolf and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowboard relay; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Temptation in the Wilderness — Matthew 4; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Windy Peak as friends gather for a snowboard relay; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Temptation in the Wilderness — Matthew 4, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_61_the_net_full_of_silverfish.md
+++ b/stories/story_61_the_net_full_of_silverfish.md
@@ -1,0 +1,133 @@
+# Story 61: The Net Full of Silverfish
+### *Inspired by Calling the First Disciples — Luke 5*
+**Characters:** Pete Penguin, Bjorn Bigpaws  
+**Setting:** Frostpeak Valley, Silverfish Cove  
+**Theme:** Calling and trust
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Silverfish Cove** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Pete Penguin tightened a scarf, looked up at the sparkling moon frost, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **cross-country challenge**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Bjorn Bigpaws handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Pete Penguin took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Calling the First Disciples — Luke 5**.
+
+"Wait," Pete Penguin said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Bjorn Bigpaws called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Calling and trust**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Pete Penguin looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Pete Penguin slowed beside Bjorn Bigpaws and smiled. "The old stories are still alive," Pete Penguin said. "They just wear snow boots now." Bjorn Bigpaws laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Calling the First Disciples — Luke 5
+- **Theme Check:** Calling and trust
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 61: The Net Full of Silverfish**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Net Full of Silverfish in Frostpeak Valley, Silverfish Cove, with Pete Penguin and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a cross-country challenge; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Calling the First Disciples — Luke 5; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Silverfish Cove as friends gather for a cross-country challenge; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Calling the First Disciples — Luke 5, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_62_the_picnic_on_powder_hill.md
+++ b/stories/story_62_the_picnic_on_powder_hill.md
@@ -1,0 +1,133 @@
+# Story 62: The Picnic on Powder Hill
+### *Inspired by Sermon on the Mount — Matthew 5–7*
+**Characters:** Teacher Tern, Barnaby Beaksworth  
+**Setting:** Frostpeak Valley, Powder Hill  
+**Theme:** Blessed are the gentle
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Powder Hill** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Teacher Tern tightened a scarf, looked up at the gentle aurora glow, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **curling scramble**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Barnaby Beaksworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Teacher Tern took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Sermon on the Mount — Matthew 5–7**.
+
+"Wait," Teacher Tern said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Barnaby Beaksworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Blessed are the gentle**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Teacher Tern looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Teacher Tern slowed beside Barnaby Beaksworth and smiled. "The old stories are still alive," Teacher Tern said. "They just wear snow boots now." Barnaby Beaksworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Sermon on the Mount — Matthew 5–7
+- **Theme Check:** Blessed are the gentle
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 62: The Picnic on Powder Hill**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Picnic on Powder Hill in Frostpeak Valley, Powder Hill, with Teacher Tern and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a curling scramble; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Sermon on the Mount — Matthew 5–7; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Powder Hill as friends gather for a curling scramble; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Sermon on the Mount — Matthew 5–7, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_63_the_rooftop_sled_rescue.md
+++ b/stories/story_63_the_rooftop_sled_rescue.md
@@ -1,0 +1,133 @@
+# Story 63: The Rooftop Sled Rescue
+### *Inspired by Friends Lower a Man Through Roof — Mark 2*
+**Characters:** Rory Reindeer, Finnegan Flipsworth  
+**Setting:** Frostpeak Valley, Roofline Village  
+**Theme:** Friends who carry each other
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Roofline Village** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Rory Reindeer tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **biathlon loop**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Finnegan Flipsworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Rory Reindeer took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Friends Lower a Man Through Roof — Mark 2**.
+
+"Wait," Rory Reindeer said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Finnegan Flipsworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Friends who carry each other**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Rory Reindeer looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Rory Reindeer slowed beside Finnegan Flipsworth and smiled. "The old stories are still alive," Rory Reindeer said. "They just wear snow boots now." Finnegan Flipsworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Friends Lower a Man Through Roof — Mark 2
+- **Theme Check:** Friends who carry each other
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 63: The Rooftop Sled Rescue**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Rooftop Sled Rescue in Frostpeak Valley, Roofline Village, with Rory Reindeer and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a biathlon loop; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Friends Lower a Man Through Roof — Mark 2; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Roofline Village as friends gather for a biathlon loop; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Friends Lower a Man Through Roof — Mark 2, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_64_mattys_tax_booth_turnaround.md
+++ b/stories/story_64_mattys_tax_booth_turnaround.md
@@ -1,0 +1,133 @@
+# Story 64: Matty's Tax-Booth Turnaround
+### *Inspired by Calling Matthew — Matthew 9*
+**Characters:** Matty Mink, Nora Snowmane  
+**Setting:** Frostpeak Valley, Checkpoint Curve  
+**Theme:** Everyone can start fresh
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Checkpoint Curve** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Matty Mink tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ski slalom**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Nora Snowmane handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Matty Mink took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Calling Matthew — Matthew 9**.
+
+"Wait," Matty Mink said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Nora Snowmane called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Everyone can start fresh**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Matty Mink looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Matty Mink slowed beside Nora Snowmane and smiled. "The old stories are still alive," Matty Mink said. "They just wear snow boots now." Nora Snowmane laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Calling Matthew — Matthew 9
+- **Theme Check:** Everyone can start fresh
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 64: Matty's Tax-Booth Turnaround**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Matty's Tax-Booth Turnaround in Frostpeak Valley, Checkpoint Curve, with Matty Mink and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ski slalom; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Calling Matthew — Matthew 9; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Checkpoint Curve as friends gather for a ski slalom; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Calling Matthew — Matthew 9, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_65_martha_mia_and_cocoa_kettle.md
+++ b/stories/story_65_martha_mia_and_cocoa_kettle.md
@@ -1,0 +1,133 @@
+# Story 65: Martha, Mia, and the Cocoa Kettle
+### *Inspired by Mary and Martha — Luke 10*
+**Characters:** Martha Marmot, Mia Mink, Willa Wobble  
+**Setting:** Frostpeak Valley, Cocoa Cottage  
+**Theme:** Presence over fussing
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Cocoa Cottage** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Martha Marmot tightened a scarf, looked up at the gold-and-violet sunset haze, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ice-dance parade**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Mia Mink handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Martha Marmot took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Mary and Martha — Luke 10**.
+
+"Wait," Martha Marmot said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Mia Mink called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Presence over fussing**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Martha Marmot looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Martha Marmot slowed beside Mia Mink and smiled. "The old stories are still alive," Martha Marmot said. "They just wear snow boots now." Mia Mink laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Mary and Martha — Luke 10
+- **Theme Check:** Presence over fussing
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 65: Martha, Mia, and the Cocoa Kettle**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Martha, Mia, and the Cocoa Kettle in Frostpeak Valley, Cocoa Cottage, with Martha Marmot and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ice-dance parade; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Mary and Martha — Luke 10; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Cocoa Cottage as friends gather for a ice-dance parade; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Mary and Martha — Luke 10, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_66_treasure_under_the_halfpipe.md
+++ b/stories/story_66_treasure_under_the_halfpipe.md
@@ -1,0 +1,133 @@
+# Story 66: Treasure Under the Halfpipe
+### *Inspired by Treasure in the Field — Matthew 13:44*
+**Characters:** Trey Trout, Piper Paddlefoot  
+**Setting:** Frostpeak Valley, Halfpipe Hollow  
+**Theme:** True treasure
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Halfpipe Hollow** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Trey Trout tightened a scarf, looked up at the powder-soft snowfall, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **sled sprint**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Piper Paddlefoot handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Trey Trout took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Treasure in the Field — Matthew 13:44**.
+
+"Wait," Trey Trout said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Piper Paddlefoot called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **True treasure**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Trey Trout looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Trey Trout slowed beside Piper Paddlefoot and smiled. "The old stories are still alive," Trey Trout said. "They just wear snow boots now." Piper Paddlefoot laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Treasure in the Field — Matthew 13:44
+- **Theme Check:** True treasure
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 66: Treasure Under the Halfpipe**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Treasure Under the Halfpipe in Frostpeak Valley, Halfpipe Hollow, with Trey Trout and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a sled sprint; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Treasure in the Field — Matthew 13:44; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Halfpipe Hollow as friends gather for a sled sprint; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Treasure in the Field — Matthew 13:44, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_67_the_pearl_of_great_powder.md
+++ b/stories/story_67_the_pearl_of_great_powder.md
@@ -1,0 +1,133 @@
+# Story 67: The Pearl of Great Powder
+### *Inspired by Pearl of Great Price — Matthew 13:45–46*
+**Characters:** Pearla Penguin, Cleo Coldwater  
+**Setting:** Frostpeak Valley, Market Square  
+**Theme:** Choosing what matters most
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Market Square** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Pearla Penguin tightened a scarf, looked up at the sparkling moon frost, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **hockey passing drill**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Cleo Coldwater handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Pearla Penguin took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Pearl of Great Price — Matthew 13:45–46**.
+
+"Wait," Pearla Penguin said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Cleo Coldwater called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Choosing what matters most**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Pearla Penguin looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Pearla Penguin slowed beside Cleo Coldwater and smiled. "The old stories are still alive," Pearla Penguin said. "They just wear snow boots now." Cleo Coldwater laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Pearl of Great Price — Matthew 13:45–46
+- **Theme Check:** Choosing what matters most
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 67: The Pearl of Great Powder**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Pearl of Great Powder in Frostpeak Valley, Market Square, with Pearla Penguin and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a hockey passing drill; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Pearl of Great Price — Matthew 13:45–46; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Market Square as friends gather for a hockey passing drill; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Pearl of Great Price — Matthew 13:45–46, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_68_the_unforgiving_skate_captain.md
+++ b/stories/story_68_the_unforgiving_skate_captain.md
@@ -1,0 +1,133 @@
+# Story 68: The Unforgiving Skate Captain
+### *Inspired by Unforgiving Servant — Matthew 18*
+**Characters:** Cap Captainybara, Bjorn Bigpaws  
+**Setting:** Frostpeak Valley, Rink Arena  
+**Theme:** Receive mercy, give mercy
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Rink Arena** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Cap Captainybara tightened a scarf, looked up at the gentle aurora glow, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowshoe trek**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Bjorn Bigpaws handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Cap Captainybara took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Unforgiving Servant — Matthew 18**.
+
+"Wait," Cap Captainybara said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Bjorn Bigpaws called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Receive mercy, give mercy**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Cap Captainybara looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Cap Captainybara slowed beside Bjorn Bigpaws and smiled. "The old stories are still alive," Cap Captainybara said. "They just wear snow boots now." Bjorn Bigpaws laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Unforgiving Servant — Matthew 18
+- **Theme Check:** Receive mercy, give mercy
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 68: The Unforgiving Skate Captain**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Unforgiving Skate Captain in Frostpeak Valley, Rink Arena, with Cap Captainybara and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowshoe trek; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Unforgiving Servant — Matthew 18; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Rink Arena as friends gather for a snowshoe trek; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Unforgiving Servant — Matthew 18, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_69_workers_at_sunset_slope.md
+++ b/stories/story_69_workers_at_sunset_slope.md
@@ -1,0 +1,133 @@
+# Story 69: Workers at Sunset Slope
+### *Inspired by Workers in the Vineyard — Matthew 20*
+**Characters:** Vinnie Vole, Barnaby Beaksworth  
+**Setting:** Frostpeak Valley, Sunset Slope  
+**Theme:** Generosity beyond fairness
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Sunset Slope** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Vinnie Vole tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **figure-skating showcase**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Barnaby Beaksworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Vinnie Vole took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Workers in the Vineyard — Matthew 20**.
+
+"Wait," Vinnie Vole said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Barnaby Beaksworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Generosity beyond fairness**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Vinnie Vole looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Vinnie Vole slowed beside Barnaby Beaksworth and smiled. "The old stories are still alive," Vinnie Vole said. "They just wear snow boots now." Barnaby Beaksworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Workers in the Vineyard — Matthew 20
+- **Theme Check:** Generosity beyond fairness
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 69: Workers at Sunset Slope**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Workers at Sunset Slope in Frostpeak Valley, Sunset Slope, with Vinnie Vole and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a figure-skating showcase; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Workers in the Vineyard — Matthew 20; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Sunset Slope as friends gather for a figure-skating showcase; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Workers in the Vineyard — Matthew 20, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_70_the_little_donkey_snow_parade.md
+++ b/stories/story_70_the_little_donkey_snow_parade.md
@@ -1,0 +1,133 @@
+# Story 70: The Little Donkey Snow Parade
+### *Inspired by Triumphal Entry — Matthew 21*
+**Characters:** Dottie Donkey, Aurora Frostholm  
+**Setting:** Frostpeak Valley, Palm Pass  
+**Theme:** Gentle leadership
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Palm Pass** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Dottie Donkey tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowboard relay**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Aurora Frostholm handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Dottie Donkey took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Triumphal Entry — Matthew 21**.
+
+"Wait," Dottie Donkey said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Aurora Frostholm called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Gentle leadership**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Dottie Donkey looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Dottie Donkey slowed beside Aurora Frostholm and smiled. "The old stories are still alive," Dottie Donkey said. "They just wear snow boots now." Aurora Frostholm laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Triumphal Entry — Matthew 21
+- **Theme Check:** Gentle leadership
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 70: The Little Donkey Snow Parade**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Little Donkey Snow Parade in Frostpeak Valley, Palm Pass, with Dottie Donkey and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowboard relay; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Triumphal Entry — Matthew 21; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Palm Pass as friends gather for a snowboard relay; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Triumphal Entry — Matthew 21, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_71_the_widows_two_snowflakes.md
+++ b/stories/story_71_the_widows_two_snowflakes.md
@@ -1,0 +1,133 @@
+# Story 71: The Widow's Two Snowflakes
+### *Inspired by Widow's Offering — Mark 12*
+**Characters:** Wida Wren, Willa Wobble  
+**Setting:** Frostpeak Valley, Giving Gazebo  
+**Theme:** Small gifts matter
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Giving Gazebo** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Wida Wren tightened a scarf, looked up at the gold-and-violet sunset haze, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **cross-country challenge**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Willa Wobble handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Wida Wren took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Widow's Offering — Mark 12**.
+
+"Wait," Wida Wren said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Willa Wobble called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Small gifts matter**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Wida Wren looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Wida Wren slowed beside Willa Wobble and smiled. "The old stories are still alive," Wida Wren said. "They just wear snow boots now." Willa Wobble laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Widow's Offering — Mark 12
+- **Theme Check:** Small gifts matter
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 71: The Widow's Two Snowflakes**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Widow's Two Snowflakes in Frostpeak Valley, Giving Gazebo, with Wida Wren and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a cross-country challenge; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Widow's Offering — Mark 12; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Giving Gazebo as friends gather for a cross-country challenge; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Widow's Offering — Mark 12, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_72_last_supper_soup_night.md
+++ b/stories/story_72_last_supper_soup_night.md
@@ -1,0 +1,133 @@
+# Story 72: Last Supper Soup Night
+### *Inspired by The Last Supper — Luke 22*
+**Characters:** Luca Lynx, Barnaby Beaksworth  
+**Setting:** Frostpeak Valley, Upper Lodge  
+**Theme:** Love that serves
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Upper Lodge** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Luca Lynx tightened a scarf, looked up at the powder-soft snowfall, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **curling scramble**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Barnaby Beaksworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Luca Lynx took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **The Last Supper — Luke 22**.
+
+"Wait," Luca Lynx said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Barnaby Beaksworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Love that serves**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Luca Lynx looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Luca Lynx slowed beside Barnaby Beaksworth and smiled. "The old stories are still alive," Luca Lynx said. "They just wear snow boots now." Barnaby Beaksworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** The Last Supper — Luke 22
+- **Theme Check:** Love that serves
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 72: Last Supper Soup Night**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Last Supper Soup Night in Frostpeak Valley, Upper Lodge, with Luca Lynx and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a curling scramble; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by The Last Supper — Luke 22; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Upper Lodge as friends gather for a curling scramble; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from The Last Supper — Luke 22, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_73_the_towel_and_skate_boots.md
+++ b/stories/story_73_the_towel_and_skate_boots.md
@@ -1,0 +1,133 @@
+# Story 73: The Towel and Skate Boots
+### *Inspired by Jesus Washes Feet — John 13*
+**Characters:** Jessie Jay, Bjorn Bigpaws  
+**Setting:** Frostpeak Valley, Locker Lodge  
+**Theme:** Servant leadership
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Locker Lodge** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Jessie Jay tightened a scarf, looked up at the sparkling moon frost, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **biathlon loop**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Bjorn Bigpaws handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Jessie Jay took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Jesus Washes Feet — John 13**.
+
+"Wait," Jessie Jay said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Bjorn Bigpaws called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Servant leadership**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Jessie Jay looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Jessie Jay slowed beside Bjorn Bigpaws and smiled. "The old stories are still alive," Jessie Jay said. "They just wear snow boots now." Bjorn Bigpaws laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Jesus Washes Feet — John 13
+- **Theme Check:** Servant leadership
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 73: The Towel and Skate Boots**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Towel and Skate Boots in Frostpeak Valley, Locker Lodge, with Jessie Jay and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a biathlon loop; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Jesus Washes Feet — John 13; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Locker Lodge as friends gather for a biathlon loop; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Jesus Washes Feet — John 13, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_74_garden_of_snowflakes.md
+++ b/stories/story_74_garden_of_snowflakes.md
@@ -1,0 +1,133 @@
+# Story 74: Garden of Snowflakes
+### *Inspired by Prayer in Gethsemane — Matthew 26*
+**Characters:** Gabe Goat, Nora Snowmane  
+**Setting:** Frostpeak Valley, Olive Glade  
+**Theme:** Prayer in hard moments
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Olive Glade** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Gabe Goat tightened a scarf, looked up at the gentle aurora glow, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ski slalom**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Nora Snowmane handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Gabe Goat took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Prayer in Gethsemane — Matthew 26**.
+
+"Wait," Gabe Goat said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Nora Snowmane called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Prayer in hard moments**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Gabe Goat looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Gabe Goat slowed beside Nora Snowmane and smiled. "The old stories are still alive," Gabe Goat said. "They just wear snow boots now." Nora Snowmane laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Prayer in Gethsemane — Matthew 26
+- **Theme Check:** Prayer in hard moments
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 74: Garden of Snowflakes**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Garden of Snowflakes in Frostpeak Valley, Olive Glade, with Gabe Goat and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ski slalom; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Prayer in Gethsemane — Matthew 26; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Olive Glade as friends gather for a ski slalom; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Prayer in Gethsemane — Matthew 26, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_75_rooster_at_the_rink_gate.md
+++ b/stories/story_75_rooster_at_the_rink_gate.md
@@ -1,0 +1,133 @@
+# Story 75: Rooster at the Rink Gate
+### *Inspired by Peter Denies Jesus — Luke 22*
+**Characters:** Petra Puffin, Pete Penguin  
+**Setting:** Frostpeak Valley, Rink Gate  
+**Theme:** Honesty after mistakes
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Rink Gate** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Petra Puffin tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ice-dance parade**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Pete Penguin handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Petra Puffin took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Peter Denies Jesus — Luke 22**.
+
+"Wait," Petra Puffin said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Pete Penguin called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Honesty after mistakes**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Petra Puffin looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Petra Puffin slowed beside Pete Penguin and smiled. "The old stories are still alive," Petra Puffin said. "They just wear snow boots now." Pete Penguin laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Peter Denies Jesus — Luke 22
+- **Theme Check:** Honesty after mistakes
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 75: Rooster at the Rink Gate**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Rooster at the Rink Gate in Frostpeak Valley, Rink Gate, with Petra Puffin and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ice-dance parade; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Peter Denies Jesus — Luke 22; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Rink Gate as friends gather for a ice-dance parade; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Peter Denies Jesus — Luke 22, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_76_the_cross_on_calvary_hill.md
+++ b/stories/story_76_the_cross_on_calvary_hill.md
@@ -1,0 +1,133 @@
+# Story 76: The Cross on Calvary Hill
+### *Inspired by Crucifixion — Luke 23*
+**Characters:** Cal Caribou, Cleo Coldwater  
+**Setting:** Frostpeak Valley, Calvary Hill  
+**Theme:** Self-giving love
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Calvary Hill** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Cal Caribou tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **sled sprint**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Cleo Coldwater handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Cal Caribou took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Crucifixion — Luke 23**.
+
+"Wait," Cal Caribou said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Cleo Coldwater called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Self-giving love**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Cal Caribou looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Cal Caribou slowed beside Cleo Coldwater and smiled. "The old stories are still alive," Cal Caribou said. "They just wear snow boots now." Cleo Coldwater laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Crucifixion — Luke 23
+- **Theme Check:** Self-giving love
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 76: The Cross on Calvary Hill**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Cross on Calvary Hill in Frostpeak Valley, Calvary Hill, with Cal Caribou and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a sled sprint; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Crucifixion — Luke 23; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Calvary Hill as friends gather for a sled sprint; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Crucifixion — Luke 23, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_77_sunrise_empty_igloo.md
+++ b/stories/story_77_sunrise_empty_igloo.md
@@ -1,0 +1,133 @@
+# Story 77: Sunrise at the Empty Igloo
+### *Inspired by Resurrection — John 20*
+**Characters:** Risa Rabbit, Piper Paddlefoot  
+**Setting:** Frostpeak Valley, Garden Igloo  
+**Theme:** Hope returns
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Garden Igloo** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Risa Rabbit tightened a scarf, looked up at the gold-and-violet sunset haze, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **hockey passing drill**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Piper Paddlefoot handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Risa Rabbit took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Resurrection — John 20**.
+
+"Wait," Risa Rabbit said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Piper Paddlefoot called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Hope returns**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Risa Rabbit looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Risa Rabbit slowed beside Piper Paddlefoot and smiled. "The old stories are still alive," Risa Rabbit said. "They just wear snow boots now." Piper Paddlefoot laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Resurrection — John 20
+- **Theme Check:** Hope returns
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 77: Sunrise at the Empty Igloo**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Sunrise at the Empty Igloo in Frostpeak Valley, Garden Igloo, with Risa Rabbit and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a hockey passing drill; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Resurrection — John 20; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Garden Igloo as friends gather for a hockey passing drill; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Resurrection — John 20, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_78_breakfast_by_frozen_shore.md
+++ b/stories/story_78_breakfast_by_frozen_shore.md
@@ -1,0 +1,133 @@
+# Story 78: Breakfast by Frozen Shore
+### *Inspired by Breakfast by the Shore — John 21*
+**Characters:** Pete Penguin, Barnaby Beaksworth  
+**Setting:** Frostpeak Valley, Shoreline Firepit  
+**Theme:** Restoration and belonging
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Shoreline Firepit** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Pete Penguin tightened a scarf, looked up at the powder-soft snowfall, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowshoe trek**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Barnaby Beaksworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Pete Penguin took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Breakfast by the Shore — John 21**.
+
+"Wait," Pete Penguin said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Barnaby Beaksworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Restoration and belonging**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Pete Penguin looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Pete Penguin slowed beside Barnaby Beaksworth and smiled. "The old stories are still alive," Pete Penguin said. "They just wear snow boots now." Barnaby Beaksworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Breakfast by the Shore — John 21
+- **Theme Check:** Restoration and belonging
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 78: Breakfast by Frozen Shore**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Breakfast by Frozen Shore in Frostpeak Valley, Shoreline Firepit, with Pete Penguin and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowshoe trek; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Breakfast by the Shore — John 21; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Shoreline Firepit as friends gather for a snowshoe trek; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Breakfast by the Shore — John 21, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_79_the_great_snowy_sendoff.md
+++ b/stories/story_79_the_great_snowy_sendoff.md
@@ -1,0 +1,133 @@
+# Story 79: The Great Snowy Send-Off
+### *Inspired by Great Commission — Matthew 28:18–20*
+**Characters:** Comet Crane, Aurora Frostholm  
+**Setting:** Frostpeak Valley, Trailhead Peak  
+**Theme:** Share good news
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Trailhead Peak** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Comet Crane tightened a scarf, looked up at the sparkling moon frost, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **figure-skating showcase**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Aurora Frostholm handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Comet Crane took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Great Commission — Matthew 28:18–20**.
+
+"Wait," Comet Crane said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Aurora Frostholm called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Share good news**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Comet Crane looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Comet Crane slowed beside Aurora Frostholm and smiled. "The old stories are still alive," Comet Crane said. "They just wear snow boots now." Aurora Frostholm laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Great Commission — Matthew 28:18–20
+- **Theme Check:** Share good news
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 79: The Great Snowy Send-Off**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Great Snowy Send-Off in Frostpeak Valley, Trailhead Peak, with Comet Crane and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a figure-skating showcase; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Great Commission — Matthew 28:18–20; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Trailhead Peak as friends gather for a figure-skating showcase; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Great Commission — Matthew 28:18–20, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_80_wind_at_winter_festival.md
+++ b/stories/story_80_wind_at_winter_festival.md
@@ -1,0 +1,133 @@
+# Story 80: Wind at the Winter Festival
+### *Inspired by Pentecost — Acts 2*
+**Characters:** Penny Ptarmigan, Finnegan Flipsworth  
+**Setting:** Frostpeak Valley, Festival Plaza  
+**Theme:** Spirit-filled courage
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Festival Plaza** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Penny Ptarmigan tightened a scarf, looked up at the gentle aurora glow, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowboard relay**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Finnegan Flipsworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Penny Ptarmigan took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Pentecost — Acts 2**.
+
+"Wait," Penny Ptarmigan said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Finnegan Flipsworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Spirit-filled courage**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Penny Ptarmigan looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Penny Ptarmigan slowed beside Finnegan Flipsworth and smiled. "The old stories are still alive," Penny Ptarmigan said. "They just wear snow boots now." Finnegan Flipsworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Pentecost — Acts 2
+- **Theme Check:** Spirit-filled courage
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 80: Wind at the Winter Festival**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Wind at the Winter Festival in Frostpeak Valley, Festival Plaza, with Penny Ptarmigan and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowboard relay; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Pentecost — Acts 2; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Festival Plaza as friends gather for a snowboard relay; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Pentecost — Acts 2, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_81_peters_picnic_blanket.md
+++ b/stories/story_81_peters_picnic_blanket.md
@@ -1,0 +1,133 @@
+# Story 81: Peter's Picnic Blanket Surprise
+### *Inspired by Peter and Cornelius — Acts 10*
+**Characters:** Pipin Penguin, Nora Snowmane  
+**Setting:** Frostpeak Valley, Open Table Rink  
+**Theme:** Welcome everyone
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Open Table Rink** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Pipin Penguin tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **cross-country challenge**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Nora Snowmane handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Pipin Penguin took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Peter and Cornelius — Acts 10**.
+
+"Wait," Pipin Penguin said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Nora Snowmane called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Welcome everyone**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Pipin Penguin looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Pipin Penguin slowed beside Nora Snowmane and smiled. "The old stories are still alive," Pipin Penguin said. "They just wear snow boots now." Nora Snowmane laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Peter and Cornelius — Acts 10
+- **Theme Check:** Welcome everyone
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 81: Peter's Picnic Blanket Surprise**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Peter's Picnic Blanket Surprise in Frostpeak Valley, Open Table Rink, with Pipin Penguin and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a cross-country challenge; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Peter and Cornelius — Acts 10; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Open Table Rink as friends gather for a cross-country challenge; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Peter and Cornelius — Acts 10, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_82_jailhouse_jingle_on_ice.md
+++ b/stories/story_82_jailhouse_jingle_on_ice.md
@@ -1,0 +1,133 @@
+# Story 82: Jailhouse Jingle on Ice
+### *Inspired by Paul and Silas in Prison — Acts 16*
+**Characters:** Silas Stoat, Paula Puffin  
+**Setting:** Frostpeak Valley, Stone Cell Rink  
+**Theme:** Joy in hard places
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Stone Cell Rink** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Silas Stoat tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **curling scramble**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Paula Puffin handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Silas Stoat took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Paul and Silas in Prison — Acts 16**.
+
+"Wait," Silas Stoat said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Paula Puffin called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Joy in hard places**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Silas Stoat looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Silas Stoat slowed beside Paula Puffin and smiled. "The old stories are still alive," Silas Stoat said. "They just wear snow boots now." Paula Puffin laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Paul and Silas in Prison — Acts 16
+- **Theme Check:** Joy in hard places
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 82: Jailhouse Jingle on Ice**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Jailhouse Jingle on Ice in Frostpeak Valley, Stone Cell Rink, with Silas Stoat and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a curling scramble; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Paul and Silas in Prison — Acts 16; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Stone Cell Rink as friends gather for a curling scramble; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Paul and Silas in Prison — Acts 16, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_83_shipwreck_snowdrift_rescue.md
+++ b/stories/story_83_shipwreck_snowdrift_rescue.md
@@ -1,0 +1,133 @@
+# Story 83: Shipwreck Snowdrift Rescue
+### *Inspired by Paul's Shipwreck — Acts 27*
+**Characters:** Paula Puffin, Bjorn Bigpaws  
+**Setting:** Frostpeak Valley, Drift Coast  
+**Theme:** Steady hope
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Drift Coast** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Paula Puffin tightened a scarf, looked up at the gold-and-violet sunset haze, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **biathlon loop**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Bjorn Bigpaws handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Paula Puffin took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Paul's Shipwreck — Acts 27**.
+
+"Wait," Paula Puffin said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Bjorn Bigpaws called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Steady hope**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Paula Puffin looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Paula Puffin slowed beside Bjorn Bigpaws and smiled. "The old stories are still alive," Paula Puffin said. "They just wear snow boots now." Bjorn Bigpaws laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Paul's Shipwreck — Acts 27
+- **Theme Check:** Steady hope
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 83: Shipwreck Snowdrift Rescue**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Shipwreck Snowdrift Rescue in Frostpeak Valley, Drift Coast, with Paula Puffin and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a biathlon loop; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Paul's Shipwreck — Acts 27; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Drift Coast as friends gather for a biathlon loop; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Paul's Shipwreck — Acts 27, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_84_armor_on_ice.md
+++ b/stories/story_84_armor_on_ice.md
@@ -1,0 +1,133 @@
+# Story 84: Armor on Ice
+### *Inspired by Armor of God — Ephesians 6*
+**Characters:** Arma Arctic-Hare, Magnus Meltsworth  
+**Setting:** Frostpeak Valley, Defense Dome  
+**Theme:** Inner strength
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Defense Dome** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Arma Arctic-Hare tightened a scarf, looked up at the powder-soft snowfall, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ski slalom**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Magnus Meltsworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Arma Arctic-Hare took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Armor of God — Ephesians 6**.
+
+"Wait," Arma Arctic-Hare said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Magnus Meltsworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Inner strength**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Arma Arctic-Hare looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Arma Arctic-Hare slowed beside Magnus Meltsworth and smiled. "The old stories are still alive," Arma Arctic-Hare said. "They just wear snow boots now." Magnus Meltsworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Armor of God — Ephesians 6
+- **Theme Check:** Inner strength
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 84: Armor on Ice**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Armor on Ice in Frostpeak Valley, Defense Dome, with Arma Arctic-Hare and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ski slalom; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Armor of God — Ephesians 6; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Defense Dome as friends gather for a ski slalom; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Armor of God — Ephesians 6, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_85_fruit_of_the_snow_spirit.md
+++ b/stories/story_85_fruit_of_the_snow_spirit.md
@@ -1,0 +1,133 @@
+# Story 85: Fruit of the Snow Spirit
+### *Inspired by Fruit of the Spirit — Galatians 5*
+**Characters:** Frida Fox, Willa Wobble  
+**Setting:** Frostpeak Valley, Orchard Iceway  
+**Theme:** Character that grows
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Orchard Iceway** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Frida Fox tightened a scarf, looked up at the sparkling moon frost, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ice-dance parade**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Willa Wobble handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Frida Fox took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Fruit of the Spirit — Galatians 5**.
+
+"Wait," Frida Fox said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Willa Wobble called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Character that grows**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Frida Fox looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Frida Fox slowed beside Willa Wobble and smiled. "The old stories are still alive," Frida Fox said. "They just wear snow boots now." Willa Wobble laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Fruit of the Spirit — Galatians 5
+- **Theme Check:** Character that grows
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 85: Fruit of the Snow Spirit**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Fruit of the Snow Spirit in Frostpeak Valley, Orchard Iceway, with Frida Fox and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ice-dance parade; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Fruit of the Spirit — Galatians 5; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Orchard Iceway as friends gather for a ice-dance parade; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Fruit of the Spirit — Galatians 5, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_86_love_on_the_chairlift.md
+++ b/stories/story_86_love_on_the_chairlift.md
@@ -1,0 +1,133 @@
+# Story 86: Love on the Chairlift
+### *Inspired by Love Is Patient — 1 Corinthians 13*
+**Characters:** Cori Cougar, Barnaby Beaksworth  
+**Setting:** Frostpeak Valley, Chairlift Line  
+**Theme:** Patient love
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Chairlift Line** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Cori Cougar tightened a scarf, looked up at the gentle aurora glow, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **sled sprint**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Barnaby Beaksworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Cori Cougar took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Love Is Patient — 1 Corinthians 13**.
+
+"Wait," Cori Cougar said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Barnaby Beaksworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Patient love**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Cori Cougar looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Cori Cougar slowed beside Barnaby Beaksworth and smiled. "The old stories are still alive," Cori Cougar said. "They just wear snow boots now." Barnaby Beaksworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Love Is Patient — 1 Corinthians 13
+- **Theme Check:** Patient love
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 86: Love on the Chairlift**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Love on the Chairlift in Frostpeak Valley, Chairlift Line, with Cori Cougar and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a sled sprint; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Love Is Patient — 1 Corinthians 13; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Chairlift Line as friends gather for a sled sprint; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Love Is Patient — 1 Corinthians 13, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_87_run_to_win_the_wreath.md
+++ b/stories/story_87_run_to_win_the_wreath.md
@@ -1,0 +1,133 @@
+# Story 87: Run to Win the Wreath
+### *Inspired by Run the Race — 1 Corinthians 9*
+**Characters:** Runa Reindeer, Piper Paddlefoot  
+**Setting:** Frostpeak Valley, Long Loop  
+**Theme:** Perseverance
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Long Loop** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Runa Reindeer tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **hockey passing drill**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Piper Paddlefoot handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Runa Reindeer took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Run the Race — 1 Corinthians 9**.
+
+"Wait," Runa Reindeer said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Piper Paddlefoot called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Perseverance**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Runa Reindeer looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Runa Reindeer slowed beside Piper Paddlefoot and smiled. "The old stories are still alive," Runa Reindeer said. "They just wear snow boots now." Piper Paddlefoot laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Run the Race — 1 Corinthians 9
+- **Theme Check:** Perseverance
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 87: Run to Win the Wreath**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Run to Win the Wreath in Frostpeak Valley, Long Loop, with Runa Reindeer and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a hockey passing drill; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Run the Race — 1 Corinthians 9; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Long Loop as friends gather for a hockey passing drill; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Run the Race — 1 Corinthians 9, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_88_joy_letter_from_snow_cell.md
+++ b/stories/story_88_joy_letter_from_snow_cell.md
@@ -1,0 +1,133 @@
+# Story 88: Joy Letter from the Snow Cell
+### *Inspired by Philippians*
+**Characters:** Phil Finch, Nora Snowmane  
+**Setting:** Frostpeak Valley, Letter Nook  
+**Theme:** Joy despite circumstances
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Letter Nook** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Phil Finch tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowshoe trek**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Nora Snowmane handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Phil Finch took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Philippians**.
+
+"Wait," Phil Finch said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Nora Snowmane called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Joy despite circumstances**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Phil Finch looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Phil Finch slowed beside Nora Snowmane and smiled. "The old stories are still alive," Phil Finch said. "They just wear snow boots now." Nora Snowmane laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Philippians
+- **Theme Check:** Joy despite circumstances
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 88: Joy Letter from the Snow Cell**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Joy Letter from the Snow Cell in Frostpeak Valley, Letter Nook, with Phil Finch and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowshoe trek; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Philippians; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Letter Nook as friends gather for a snowshoe trek; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Philippians, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_89_the_new_coat_self.md
+++ b/stories/story_89_the_new_coat_self.md
@@ -1,0 +1,133 @@
+# Story 89: The New Coat Self
+### *Inspired by Colossians 3*
+**Characters:** Cole Cat, Cleo Coldwater  
+**Setting:** Frostpeak Valley, Costume Cabin  
+**Theme:** Put on kindness daily
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Costume Cabin** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Cole Cat tightened a scarf, looked up at the gold-and-violet sunset haze, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **figure-skating showcase**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Cleo Coldwater handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Cole Cat took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Colossians 3**.
+
+"Wait," Cole Cat said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Cleo Coldwater called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Put on kindness daily**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Cole Cat looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Cole Cat slowed beside Cleo Coldwater and smiled. "The old stories are still alive," Cole Cat said. "They just wear snow boots now." Cleo Coldwater laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Colossians 3
+- **Theme Check:** Put on kindness daily
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 89: The New Coat Self**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The New Coat Self in Frostpeak Valley, Costume Cabin, with Cole Cat and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a figure-skating showcase; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Colossians 3; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Costume Cabin as friends gather for a figure-skating showcase; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Colossians 3, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_90_cloud_of_snowy_witnesses.md
+++ b/stories/story_90_cloud_of_snowy_witnesses.md
@@ -1,0 +1,133 @@
+# Story 90: Cloud of Snowy Witnesses
+### *Inspired by Hebrews 12*
+**Characters:** Hebe Heron, Bjorn Bigpaws  
+**Setting:** Frostpeak Valley, Stadium Loop  
+**Theme:** Encouragement
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Stadium Loop** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Hebe Heron tightened a scarf, looked up at the powder-soft snowfall, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowboard relay**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Bjorn Bigpaws handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Hebe Heron took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Hebrews 12**.
+
+"Wait," Hebe Heron said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Bjorn Bigpaws called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Encouragement**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Hebe Heron looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Hebe Heron slowed beside Bjorn Bigpaws and smiled. "The old stories are still alive," Hebe Heron said. "They just wear snow boots now." Bjorn Bigpaws laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Hebrews 12
+- **Theme Check:** Encouragement
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 90: Cloud of Snowy Witnesses**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Cloud of Snowy Witnesses in Frostpeak Valley, Stadium Loop, with Hebe Heron and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowboard relay; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Hebrews 12; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Stadium Loop as friends gather for a snowboard relay; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Hebrews 12, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_91_taming_the_tiny_tongue.md
+++ b/stories/story_91_taming_the_tiny_tongue.md
@@ -1,0 +1,133 @@
+# Story 91: Taming the Tiny Tongue
+### *Inspired by James 3*
+**Characters:** Jem Jay, Willa Wobble  
+**Setting:** Frostpeak Valley, Commentator Booth  
+**Theme:** Kind words
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Commentator Booth** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Jem Jay tightened a scarf, looked up at the sparkling moon frost, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **cross-country challenge**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Willa Wobble handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Jem Jay took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **James 3**.
+
+"Wait," Jem Jay said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Willa Wobble called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Kind words**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Jem Jay looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Jem Jay slowed beside Willa Wobble and smiled. "The old stories are still alive," Jem Jay said. "They just wear snow boots now." Willa Wobble laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** James 3
+- **Theme Check:** Kind words
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 91: Taming the Tiny Tongue**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Taming the Tiny Tongue in Frostpeak Valley, Commentator Booth, with Jem Jay and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a cross-country challenge; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by James 3; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Commentator Booth as friends gather for a cross-country challenge; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from James 3, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_92_faith_and_ice_bridge.md
+++ b/stories/story_92_faith_and_ice_bridge.md
@@ -1,0 +1,133 @@
+# Story 92: Faith and the Ice Bridge
+### *Inspired by James 2*
+**Characters:** Faye Ferret, Finnegan Flipsworth  
+**Setting:** Frostpeak Valley, Bridge Creek  
+**Theme:** Faith in action
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Bridge Creek** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Faye Ferret tightened a scarf, looked up at the gentle aurora glow, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **curling scramble**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Finnegan Flipsworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Faye Ferret took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **James 2**.
+
+"Wait," Faye Ferret said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Finnegan Flipsworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Faith in action**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Faye Ferret looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Faye Ferret slowed beside Finnegan Flipsworth and smiled. "The old stories are still alive," Faye Ferret said. "They just wear snow boots now." Finnegan Flipsworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** James 2
+- **Theme Check:** Faith in action
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 92: Faith and the Ice Bridge**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Faith and the Ice Bridge in Frostpeak Valley, Bridge Creek, with Faye Ferret and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a curling scramble; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by James 2; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Bridge Creek as friends gather for a curling scramble; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from James 2, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_93_fiery_dart_snowballs.md
+++ b/stories/story_93_fiery_dart_snowballs.md
@@ -1,0 +1,133 @@
+# Story 93: Fiery Dart Snowballs
+### *Inspired by 1 Peter 5*
+**Characters:** Peter Pika, Magnus Meltsworth  
+**Setting:** Frostpeak Valley, Snowball Field  
+**Theme:** Resilience
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Snowball Field** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Peter Pika tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **biathlon loop**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Magnus Meltsworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Peter Pika took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **1 Peter 5**.
+
+"Wait," Peter Pika said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Magnus Meltsworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Resilience**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Peter Pika looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Peter Pika slowed beside Magnus Meltsworth and smiled. "The old stories are still alive," Peter Pika said. "They just wear snow boots now." Magnus Meltsworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** 1 Peter 5
+- **Theme Check:** Resilience
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 93: Fiery Dart Snowballs**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Fiery Dart Snowballs in Frostpeak Valley, Snowball Field, with Peter Pika and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a biathlon loop; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by 1 Peter 5; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Snowball Field as friends gather for a biathlon loop; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from 1 Peter 5, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_94_good_shepherd_ski_whistle.md
+++ b/stories/story_94_good_shepherd_ski_whistle.md
@@ -1,0 +1,133 @@
+# Story 94: The Good Shepherd Ski Whistle
+### *Inspired by The Good Shepherd — John 10*
+**Characters:** Shira Sheep, Nora Snowmane  
+**Setting:** Frostpeak Valley, Meadow Run  
+**Theme:** Being known and guided
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Meadow Run** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Shira Sheep tightened a scarf, looked up at the tiny crystal flurries, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ski slalom**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Nora Snowmane handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Shira Sheep took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **The Good Shepherd — John 10**.
+
+"Wait," Shira Sheep said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Nora Snowmane called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Being known and guided**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Shira Sheep looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Shira Sheep slowed beside Nora Snowmane and smiled. "The old stories are still alive," Shira Sheep said. "They just wear snow boots now." Nora Snowmane laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** The Good Shepherd — John 10
+- **Theme Check:** Being known and guided
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 94: The Good Shepherd Ski Whistle**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The Good Shepherd Ski Whistle in Frostpeak Valley, Meadow Run, with Shira Sheep and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ski slalom; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by The Good Shepherd — John 10; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Meadow Run as friends gather for a ski slalom; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from The Good Shepherd — John 10, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_95_wedding_feast_white_mountain.md
+++ b/stories/story_95_wedding_feast_white_mountain.md
@@ -1,0 +1,133 @@
+# Story 95: Wedding Feast on White Mountain
+### *Inspired by Wedding Banquet — Matthew 22*
+**Characters:** Wendy Weasel, Barnaby Beaksworth  
+**Setting:** Frostpeak Valley, White Mountain Hall  
+**Theme:** Everyone invited
+
+---
+
+## Opening Wink
+
+Tonight the snow fell in slow swirls, like the sky was carefully sprinkling powdered sugar over every rooftop in Frostpeak Valley.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **White Mountain Hall** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Wendy Weasel tightened a scarf, looked up at the gold-and-violet sunset haze, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **ice-dance parade**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Barnaby Beaksworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Teddy and Tilda attempted synchronized snow-angels in their boots and accidentally made what looked like two giant pancakes.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Wendy Weasel took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Wedding Banquet — Matthew 22**.
+
+"Wait," Wendy Weasel said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Barnaby Beaksworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Everyone invited**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Wendy Weasel looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Wendy Weasel slowed beside Barnaby Beaksworth and smiled. "The old stories are still alive," Wendy Weasel said. "They just wear snow boots now." Barnaby Beaksworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Wedding Banquet — Matthew 22
+- **Theme Check:** Everyone invited
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 95: Wedding Feast on White Mountain**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Wedding Feast on White Mountain in Frostpeak Valley, White Mountain Hall, with Wendy Weasel and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a ice-dance parade; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Wedding Banquet — Matthew 22; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, White Mountain Hall as friends gather for a ice-dance parade; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Wedding Banquet — Matthew 22, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_96_oil_for_snow_lamps.md
+++ b/stories/story_96_oil_for_snow_lamps.md
@@ -1,0 +1,133 @@
+# Story 96: Oil for the Snow Lamps
+### *Inspired by Ten Virgins — Matthew 25*
+**Characters:** Ollie Owl, Willa Wobble  
+**Setting:** Frostpeak Valley, Lamp Ridge  
+**Theme:** Ready hearts
+
+---
+
+## Opening Wink
+
+The moon wore a silver halo, the cocoa kettles hissed cheerfully, and somewhere in the dark a seal clapped for absolutely no reason.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Lamp Ridge** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Ollie Owl tightened a scarf, looked up at the powder-soft snowfall, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **sled sprint**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Willa Wobble handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Finnegan announced a brilliant plan, forgot the middle of the plan, then improvised a finale involving three cones and a fish cracker.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Ollie Owl took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Ten Virgins — Matthew 25**.
+
+"Wait," Ollie Owl said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Willa Wobble called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Ready hearts**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Ollie Owl looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Ollie Owl slowed beside Willa Wobble and smiled. "The old stories are still alive," Ollie Owl said. "They just wear snow boots now." Willa Wobble laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Ten Virgins — Matthew 25
+- **Theme Check:** Ready hearts
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 96: Oil for the Snow Lamps**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Oil for the Snow Lamps in Frostpeak Valley, Lamp Ridge, with Ollie Owl and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a sled sprint; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Ten Virgins — Matthew 25; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Lamp Ridge as friends gather for a sled sprint; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Ten Virgins — Matthew 25, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_97_zacchaeus_tree_lift.md
+++ b/stories/story_97_zacchaeus_tree_lift.md
@@ -1,0 +1,133 @@
+# Story 97: Zacchaeus and the Tree Lift
+### *Inspired by Zacchaeus — Luke 19*
+**Characters:** Zack Zebra, Piper Paddlefoot  
+**Setting:** Frostpeak Valley, Pine Lift  
+**Theme:** Change of heart
+
+---
+
+## Opening Wink
+
+If bedtime had a sound, it would be this: ski edges whispering on powder, distant laughter, and one happy narwhal doing dramatic twirls.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Pine Lift** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Zack Zebra tightened a scarf, looked up at the sparkling moon frost, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **hockey passing drill**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Piper Paddlefoot handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Captain Prism the narwhal surfaced through a lake-hole, bowed to nobody in particular, and declared, 'Proceed with heroic snack-energy!'
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Zack Zebra took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Zacchaeus — Luke 19**.
+
+"Wait," Zack Zebra said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Piper Paddlefoot called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Change of heart**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Zack Zebra looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Zack Zebra slowed beside Piper Paddlefoot and smiled. "The old stories are still alive," Zack Zebra said. "They just wear snow boots now." Piper Paddlefoot laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Zacchaeus — Luke 19
+- **Theme Check:** Change of heart
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 97: Zacchaeus and the Tree Lift**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Zacchaeus and the Tree Lift in Frostpeak Valley, Pine Lift, with Zack Zebra and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a hockey passing drill; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Zacchaeus — Luke 19; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Pine Lift as friends gather for a hockey passing drill; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Zacchaeus — Luke 19, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_98_friend_at_midnight_cocoa.md
+++ b/stories/story_98_friend_at_midnight_cocoa.md
@@ -1,0 +1,133 @@
+# Story 98: Friend at Midnight Cocoa
+### *Inspired by Friend at Midnight — Luke 11*
+**Characters:** Coco Crow, Barnaby Beaksworth  
+**Setting:** Frostpeak Valley, Midnight Alley  
+**Theme:** Persistent kindness
+
+---
+
+## Opening Wink
+
+The valley lights glowed amber and soft, and the mountain wind sounded almost like a lullaby humming through pine trees.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Midnight Alley** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Coco Crow tightened a scarf, looked up at the gentle aurora glow, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **snowshoe trek**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Barnaby Beaksworth handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Nibbles and Splash tried to judge the event with tiny scorecards that were mostly doodles of fish wearing helmets.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Coco Crow took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **Friend at Midnight — Luke 11**.
+
+"Wait," Coco Crow said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Barnaby Beaksworth called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Persistent kindness**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Coco Crow looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Coco Crow slowed beside Barnaby Beaksworth and smiled. "The old stories are still alive," Coco Crow said. "They just wear snow boots now." Barnaby Beaksworth laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** Friend at Midnight — Luke 11
+- **Theme Check:** Persistent kindness
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 98: Friend at Midnight Cocoa**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> Friend at Midnight Cocoa in Frostpeak Valley, Midnight Alley, with Coco Crow and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a snowshoe trek; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by Friend at Midnight — Luke 11; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Midnight Alley as friends gather for a snowshoe trek; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from Friend at Midnight — Luke 11, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.

--- a/stories/story_99_new_sky_snow_carnival.md
+++ b/stories/story_99_new_sky_snow_carnival.md
@@ -1,0 +1,133 @@
+# Story 99: The New Sky Snow Carnival
+### *Inspired by A New Heaven and New Earth — Revelation 21*
+**Characters:** Nova Narwhal, Aurora Frostholm  
+**Setting:** Frostpeak Valley, Carnival Ridge  
+**Theme:** Future hope
+
+---
+
+## Opening Wink
+
+It was one of those glittering nights when mittens went missing, friends found them anyway, and everything felt possible.
+
+## The Story
+
+By the time evening bells chimed in Frostpeak Valley, every path to **Carnival Ridge** glimmered with lantern light. Snowflakes drifted in that dreamy, unhurried way that makes everybody walk softer and talk gentler. Nova Narwhal tightened a scarf, looked up at the playful crosswind, and grinned like tonight might be the best story-night yet.
+
+"Slide into it!" came a voice from up the trail, followed by laughter and the sound of boots crunching over fresh powder. Soon friends gathered in a cheerful crowd—some with boards over their shoulders, some balancing skis, some carrying baskets of warm rolls wrapped in cloth so they stayed toasty.
+
+Tonight's valley activity was a playful **figure-skating showcase**, not for trophies, but for teamwork. A banner flapped overhead. Bells twinkled from a nearby pine. Even the little ones stood extra tall, trying to look very official. Aurora Frostholm handed out glow-sticks and whispered, "No matter what happens, we keep it kind and cozy." Everybody nodded.
+
+Then, naturally, things got wobbly.
+
+The route markers were slightly mixed up, one team forgot where the turn was, and Finnegan gave three dramatic instructions at once. "Left-ish! No, right-ish! Actually... confidence-ish!" he cried, pointing in three directions and somehow nearly tripping over a bucket of fish crackers.
+
+Herschel the Walrus claimed he was only there for safety oversight, but everyone noticed the safety oversight looked exactly like a cocoa cart.
+
+For a minute, the valley felt noisy and tangled. Friends talked over each other. A few little riders looked worried. Someone muttered, "Maybe we should quit and try tomorrow." But Nova Narwhal took a deep breath, listened to the wind, and remembered the old story this adventure was built from: **A New Heaven and New Earth — Revelation 21**.
+
+"Wait," Nova Narwhal said, raising one mittened flipper. "Let's do this the heart-way first." That made everybody pause.
+
+So they reset the moment with small, brave choices. One group relit lanterns and lined them along the safe trail. Another checked in with younger riders. Barnaby organized a snack station labeled **COURAGE CRACKERS** in glitter pen. Willa re-tied loose straps and quietly reminded everyone, "The smallest step is still a step."
+
+As the crowd settled, something changed in the air. The panic melted. Conversation softened. The challenge that looked huge became a puzzle friends could solve together. Aurora Frostholm called out steady directions. Bjorn paced the edge like a gentle guardian. Cleo sketched quick map arrows in the snow with the tip of her board.
+
+When the next round began, it looked almost magical. Skis carved silver lines. Boards kicked up sparkling spray. Tiny helmets bobbed through turns like bright winter berries. Seals clapped in perfect rhythm. A narwhal cheer erupted from the frozen lake, completely off-tempo and absolutely appreciated.
+
+Halfway through, one rider slipped near a bend. Before fear could grow, two teammates linked paws, steadied them, and kept moving together. The whole crowd cheered—not because it was flashy, but because it was kind. That, everyone agreed, was the real gold medal move.
+
+By the final bell, cheeks were rosy, mittens were frosty, and hearts felt bigger than when the night began. They had finished the challenge, yes—but more importantly, they had lived the lesson: **Future hope**.
+
+Afterward, everyone circled up near the cocoa fires. Steam curled from mugs. Someone passed cinnamon fish-cookies. Teddy and Tilda performed a short interpretive dance called *The Avalanche of Hugs* that ended with both of them giggling on a snowbank.
+
+"You know what I love?" said Nora softly. "How this valley always remembers people matter more than perfect plans."
+
+"I do enjoy perfect plans," Bjorn replied, adjusting his scarf with dignity. "But I enjoy people more." That earned a happy round of applause and one dramatic horn-blast from Captain Prism.
+
+As stars brightened overhead, Nova Narwhal looked around at friends bundled in quilts and moonlight. The old story from long ago had become a new story tonight—full of laughter, courage, and warm-hearted choices on a cold mountain evening.
+
+"Tomorrow," Barnaby declared, lifting his cocoa mug, "we do it again. Maybe with fewer accidental cartwheels."
+
+No one promised that part, but everyone smiled.
+
+And when they finally headed home, the valley grew quiet in the sweetest way: tracks in fresh snow, lanterns dimming one by one, and sleepy little voices retelling favorite moments all the way to bed.
+
+
+Before the group packed up, Cleo suggested one last "kindness lap" with no timer at all. Riders paired up—fast with slow, confident with wobbly, chatty with shy. They practiced cheering for every small win: a clean turn, a brave retry, a shared mitten, a steady breath after a stumble. It turned out the quietest lap of the night was somehow the most exciting.
+
+Then Herschel rolled in his cocoa cart with a little bell and announced, "Post-adventure reflections and marshmallow logistics now open!" One by one, friends shared what they learned. Some said they learned patience. Some said they learned to ask for help earlier. One tiny otter said, "I learned that falling down is less scary when somebody already has a hand out." Everybody agreed that was excellent wisdom.
+
+On the walk back, the sky stretched wide and deep like velvet, and the stars looked close enough to count. Nova Narwhal slowed beside Aurora Frostholm and smiled. "The old stories are still alive," Nova Narwhal said. "They just wear snow boots now." Aurora Frostholm laughed softly. "And sometimes a helmet with a pom-pom."
+
+At the edge of the village, porch lights blinked on in warm gold rows. Scarves were shaken out, boards were stacked, and sleepy yawns spread faster than rumors at breakfast. Frostpeak settled into its midnight hush, holding tonight's lesson like a glowing ember: strong enough to keep, gentle enough to share.
+
+---
+
+## Cozy Landing
+
+When life feels slippery, you can slow down, breathe deep, and choose the kind next step. Kindness turns confusion into courage, and courage turns cold nights warm.
+
+## Allegory Fun Alignment (Revision Pass 2)
+
+- **Inspiration:** A New Heaven and New Earth — Revelation 21
+- **Theme Check:** Future hope
+- **Winter Silly Hook:** Keep at least one playful snow-creature beat (seal applause, narwhal cameo, penguin wobble-save, etc.).
+
+## Snowy Giggle Check-In
+
+- What made you giggle most in **Story 99: The New Sky Snow Carnival**?
+- Which character would you bring on your snowy adventure tonight?
+- If you made a sequel, what funny winter challenge would happen next?
+
+## Fun Theme Checklist (Revision Pass 1)
+
+- ✅ Theme core is clear
+- ✅ Winter fun element present
+- ✅ Silly moment included
+- ✅ Cozy ending preserved
+- ✅ Bedtime-safe tone maintained
+
+## Goodnight Blessing
+
+*May your heart be steady when plans get wobbly.*  
+*May your kindness shine brighter than any lantern.*  
+*May your dreams be soft as fresh snow and warm as cocoa by the fire.*  
+*Goodnight, little rider. Sleep safely, sleep deeply, sleep full of wonder.*
+
+---
+
+## Image Prompts
+
+**Cover Illustration:**  
+> The New Sky Snow Carnival in Frostpeak Valley, Carnival Ridge, with Nova Narwhal and friends under glowing lanterns, cozy snowfall, playful motion, and warm storybook lighting; whimsical children's illustration style.
+
+**Scene 1 — Winter Challenge Begins:**  
+> Frostpeak crowd preparing for a figure-skating showcase; colorful skis and snowboards, scarf flutter, smiling faces, mountain twilight, cinematic wide shot.
+
+**Scene 2 — The Wobbly Problem:**  
+> Mid-story mix-up inspired by A New Heaven and New Earth — Revelation 21; characters helping each other, snow spray, expressive reactions, gentle humor, medium character shot.
+
+**Scene 3 — Cozy Victory Circle:**  
+> Aurora-lit ending with cocoa mugs, group laughter, glowing lodge lights, snowy textures, comforting bedtime mood.
+
+---
+
+## Video Prompts
+
+**Opening Sequence:**  
+> Aerial glide over Frostpeak Valley at dusk, descending toward Frostpeak Valley, Carnival Ridge as friends gather for a figure-skating showcase; soft orchestral music, whimsical family animation.
+
+**Challenge + Heart Turn:**  
+> A playful setback creates confusion, then the group remembers the lesson from A New Heaven and New Earth — Revelation 21, coordinates kindly, and turns chaos into teamwork; include close-ups and drifting snow particles.
+
+**Triumphant Bedtime Close:**  
+> The challenge completed, friends share cocoa by lantern light, aurora sweeping overhead, slow pullback to a peaceful mountain night for a sleepy ending.
+
+## Cinematic Prompt Enhancers (Phase 3)
+
+- **Character Lock:** Keep recurring Frostpeak characters visually consistent (board colors, scarf colors, size relationships).
+- **Style Lock:** cozy storybook fantasy, aurora glow, warm rim light, expressive faces, playful winter motion.
+- **Camera Mix:** include one wide establishing shot, one medium character shot, and one low-angle action shot.
+- **Motion Cues:** snow spray, scarf flutter, tiny slips + recoveries, cheering crowd reactions.
+- **Kid-Safe Tone:** adventurous but never frightening; wonder over peril.
+- **Negative Prompt (optional):** no horror, no weapons, no harsh realism, no gloomy desaturated palette.


### PR DESCRIPTION
### Motivation

- Grow the Frostpeak Valley bedtime collection from 20 to a full 100-story catalog so each allegory has its own file and consistent prompts. 
- Surface the expanded collection in the top-level docs so readers and tooling can find every story and its image/video prompts easily.

### Description

- Updated `README.md` to advertise the full `100`-story collection and renamed the core table to show the foundational `1–20` stories. 
- Added a new catalog `FROSTPEAK_100_BIBLE_BEDTIME_STORIES.md` that lists and links stories `1–100` in `stories/` with their Biblical inspirations. 
- Added many new story files under `stories/` (stories `21` through `100`, e.g. `stories/story_21_the_rainbow_over_rink_ridge.md` … `stories/story_100_river_of_life_ice_rink.md`) each including story text, `Goodnight Blessing`, `Image Prompts`, and `Video Prompts`. 
- Updated `CHARACTER_AND_STORY_GUIDE.md` to note the expanded `100-story` collection and point to the new catalog and `stories/` directory.

### Testing

- Ran `markdownlint` on changed Markdown files to check formatting and it passed. 
- Ran a quick verification script that ensures every entry in `FROSTPEAK_100_BIBLE_BEDTIME_STORIES.md` has a corresponding file in `stories/`, and that check succeeded. 
- No unit tests required for content-only additions; CI should pick up the new files and the static checks above on the next pipeline run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e7117daa08326a5bb11d799a5f681)