### PR TITLE
Prefer branch story versions during merge by setting merge=ours for stories

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Prefer the branch's expanded story content when resolving merges.
+stories/story_*.md merge=ours


### PR DESCRIPTION
### Motivation
- Preserve the longer, expanded story content from the current branch when merging into `main` by preferring branch versions for story files.

### Description
- Add a repository-level `.gitattributes` file that sets `stories/story_*.md merge=ours` so story markdown files favor the branch copy during merge conflict resolution.
- Include a short comment in `.gitattributes` explaining the intent to prefer the branch's expanded story content.

### Testing
- Ran `git check-attr merge -- stories/story_01_the_great_slush_flood.md` to verify the `merge=ours` attribute is active and it succeeded.
- Ran `git status --short --branch` to confirm the working tree is clean and it succeeded.
- Inspected the created `.gitattributes` file contents with `nl -ba .gitattributes` to confirm the rule was written and it matched the expected lines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e77fd7d34832694cfc287bd30413f)